### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/05-AdvancedTopics/mcp-oauth2-demo/src/main/java/com/example/mcp/SecurityConfiguration.java
+++ b/05-AdvancedTopics/mcp-oauth2-demo/src/main/java/com/example/mcp/SecurityConfiguration.java
@@ -40,7 +40,7 @@ public class SecurityConfiguration {
         
         http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
-            .csrf(csrf -> csrf.disable());
+            .csrf(Customizer.withDefaults());
         
         return http.build();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/mcp-for-beginners/security/code-scanning/1](https://github.com/microsoft/mcp-for-beginners/security/code-scanning/1)

To fix the issue, CSRF protection should be enabled by removing the `csrf.disable()` call. If there are specific endpoints that do not require CSRF protection (e.g., APIs used by non-browser clients), those endpoints can be explicitly excluded from CSRF protection using Spring's `RequestMatcher` or similar mechanisms. This ensures that CSRF protection is applied where necessary while allowing flexibility for specific use cases.

The changes will involve:
1. Removing the `csrf.disable()` call on line 43.
2. Optionally, configuring CSRF protection to exclude specific endpoints if needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
