### PR TITLE
New Agent button

### DIFF
--- a/03-GettingStarted/06-aitk/README.md
+++ b/03-GettingStarted/06-aitk/README.md
@@ -60,7 +60,7 @@ The **Agent (Prompt) Builder** enables you to create and customize your own AI-p
 
 1. Open the **AI Toolkit** extension from the **Activity Bar**.
 1. In the **Tools** section, select **Agent (Prompt) Builder**. Selecting **Agent (Prompt) Builder** opens the **Agent (Prompt) Builder** in a new editor tab.
-1. Click the **+ New Builder** button. The extension will launch a setup wizard via the **Command Palette**.
+1. Click the **+ New Agent** button. The extension will launch a setup wizard via the **Command Palette**.
 1. Enter the name **Calculator Agent** and press **Enter**.
 1. In the **Agent (Prompt) Builder**, for the **Model** field, select the **OpenAI GPT-4o (via GitHub)** model.
 


### PR DESCRIPTION
The `+ New Builder` button seems to have been replaced with the `+ New Agent ` button.
![githubmcp](https://github.com/user-attachments/assets/7bf97645-a519-4f77-88a1-5dfbb326a252)

# Purpose

Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x ] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```
