### PR TITLE
fix / discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/microsoft/mcp-for-beginners?style=social&label=Star)](https://GitHub.com/microsoft/mcp-for-beginners/stargazers)
 
 
-[![Microsoft Azure AI Foundry Discord](https://dcbadge.vercel.app/api/server/ByRwuEEgH4)](https://discord.com/invite/ByRwuEEgH4)
-
+[![Microsoft Azure AI Foundry Discord](https://dcbadge.limes.pink/api/server/ByRwuEEgH4)](https://discord.com/invite/ByRwuEEgH4)
 
 Follow these steps to get started using these resources:
 1. **Fork the Repository**: Click [![GitHub forks](https://img.shields.io/github/forks/microsoft/mcp-for-beginners.svg?style=social&label=Fork)](https://GitHub.com/microsoft/mcp-for-beginners/fork)


### PR DESCRIPTION
# Purpose

Fix the Discord badge appearance in README. As shown below, it is not currently rendered likely because the relevant `dcbadge.vercel.app` returns a 404. Switching to use the [recommended `dcbadge.limes.pink` server](https://github.com/gitlimes/dcbadge) seems to fix it.

![image](https://github.com/user-attachments/assets/80266808-e0a5-4486-a4fa-603a46645ea6)


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
