### PR TITLE
Fix image links in 03-GettingStarted/04-vscode

### DIFF
--- a/03-GettingStarted/04-vscode/README.md
+++ b/03-GettingStarted/04-vscode/README.md
@@ -29,9 +29,9 @@ You can control your MCP server in two different ways:
   <details>
   <summary>Screenshots</summary>
 
-  ![Guided MCP server configuration in Visual Studio Code](../images/03-GettingStarted/chat-mode-agent.png)
-  ![Tool selection per agent session](../images/03-GettingStarted/agent-mode-select-tools.png)
-  ![Easily debug errors during MCP development](../images/03-GettingStarted/mcp-list-servers.png)
+  ![Guided MCP server configuration in Visual Studio Code](../../images/03-GettingStarted/chat-mode-agent.png)
+  ![Tool selection per agent session](../../images/03-GettingStarted/agent-mode-select-tools.png)
+  ![Easily debug errors during MCP development](../../images/03-GettingStarted/mcp-list-servers.png)
   </details>
 
 Let's talk more about how we use the visual interface in the next sections.


### PR DESCRIPTION
# Purpose

Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?

Hi😀 Thanks for the useful tutorial!
The purpose of this change is to fix broken image links in the `03-GettingStarted/04-vscode` section.  

<img width="1073" height="447" alt="image" src="https://github.com/user-attachments/assets/e125e41a-98d1-4c1b-b88d-fd50b35dc604" />

Thank you👍 

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```