### PR TITLE
Remove "Flask" in python sdk key features

### DIFF
--- a/04-PracticalImplementation/README.md
+++ b/04-PracticalImplementation/README.md
@@ -121,7 +121,7 @@ The Python SDK offers a Pythonic approach to MCP implementation with excellent M
 ### Key Features
 
 - Async/await support with asyncio
-- Flask and FastAPI integration
+- FastAPI integration``
 - Simple tool registration
 - Native integration with popular ML libraries
 


### PR DESCRIPTION
# Purpose

Didn't saw any useful information about python-sdk support Flask.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```
