### PR TITLE
Update co-op-translator.yml

### DIFF
--- a/.github/workflows/co-op-translator.yml
+++ b/.github/workflows/co-op-translator.yml
@@ -53,8 +53,8 @@ jobs:
           # IMPORTANT: Set your target languages here (REQUIRED CONFIGURATION)
           # =====================================================================
           # Example: Translate to Spanish, French, German. Add -y to auto-confirm.
-          translate -l "all" -y  # <--- MODIFY THIS LINE with your desired languages
-          # translate -l "zh tw hk fr ja ko pt es de fa pl hi" -y
+          # translate -l "all" -y  # <--- MODIFY THIS LINE with your desired languages
+           translate -l "zh tw hk fr ja ko pt es de fa pl hi" -y
 
       - name: Authenticate GitHub App
         id: generate_token


### PR DESCRIPTION
split translation

# Purpose

Spitting translation due to timeout

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
