### PR TITLE
Update co-op-translator.yml back to all

### DIFF
--- a/.github/workflows/co-op-translator.yml
+++ b/.github/workflows/co-op-translator.yml
@@ -53,10 +53,10 @@ jobs:
           # IMPORTANT: Set your target languages here (REQUIRED CONFIGURATION)
           # =====================================================================
           # Example: Translate to Spanish, French, German. Add -y to auto-confirm.
-          # translate -l "all" -y  # <--- MODIFY THIS LINE with your desired languages
+          translate -l "all" -y  # <--- MODIFY THIS LINE with your desired languages
           # Recommendation for large batches over 29 files run them in batches maximum github runner time is 6 hours
           # translate -l "zh tw hk fr ja ko pt es de fa pl hi" -y
-           translate -l "ru ar ur mo ja bn mr ne pa br it tr" -y
+          # translate -l "ru ar ur mo ja bn mr ne pa br it tr" -y
           # translate -l "el th sv da no fi nl he vi id ms tl" -y
           # translate -l "sw hu cs sk ro bg sr hr sl uk my" -y
 


### PR DESCRIPTION
setting translations back to all languages

# Purpose

Setting language translations back to all languages based on refactoring large sets of resources

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
