### PR TITLE
Add warning for macOS users

### DIFF
--- a/03-GettingStarted/07-aitk/README.md
+++ b/03-GettingStarted/07-aitk/README.md
@@ -38,8 +38,8 @@ Great, now that we understand the flow, let's configure an AI agent to leverage 
 
 ## Exercise: Consuming a server
 
-⚠️ **Note for macOS Users:**
-We're currently investigating an issue affecting dependency installation on macOS. As a result, macOS users won’t be able to complete this tutorial at this time. We’ll update the instructions as soon as a fix is available. Thank you for your patience and understanding!
+> [!WARNING]
+> Note for macOS Users. We're currently investigating an issue affecting dependency installation on macOS. As a result, macOS users won’t be able to complete this tutorial at this time. We’ll update the instructions as soon as a fix is available. Thank you for your patience and understanding!
 
 In this exercise, you will build, run, and enhance an AI agent with tools from a MCP server inside Visual Studio Code using the AI Toolkit.
 

--- a/03-GettingStarted/07-aitk/README.md
+++ b/03-GettingStarted/07-aitk/README.md
@@ -38,6 +38,9 @@ Great, now that we understand the flow, let's configure an AI agent to leverage 
 
 ## Exercise: Consuming a server
 
+⚠️ **Note for Mac Users:**
+We're currently investigating an issue affecting dependency installation on macOS. As a result, Mac users won’t be able to complete this tutorial at this time. We’ll update the instructions as soon as a fix is available. Thank you for your patience and understanding!
+
 In this exercise, you will build, run, and enhance an AI agent with tools from a MCP server inside Visual Studio Code using the AI Toolkit.
 
 ### -0- Prestep, add the OpenAI GPT-4o model to My Models

--- a/03-GettingStarted/07-aitk/README.md
+++ b/03-GettingStarted/07-aitk/README.md
@@ -38,8 +38,8 @@ Great, now that we understand the flow, let's configure an AI agent to leverage 
 
 ## Exercise: Consuming a server
 
-⚠️ **Note for Mac Users:**
-We're currently investigating an issue affecting dependency installation on macOS. As a result, Mac users won’t be able to complete this tutorial at this time. We’ll update the instructions as soon as a fix is available. Thank you for your patience and understanding!
+⚠️ **Note for macOS Users:**
+We're currently investigating an issue affecting dependency installation on macOS. As a result, macOS users won’t be able to complete this tutorial at this time. We’ll update the instructions as soon as a fix is available. Thank you for your patience and understanding!
 
 In this exercise, you will build, run, and enhance an AI agent with tools from a MCP server inside Visual Studio Code using the AI Toolkit.
 


### PR DESCRIPTION
# Purpose

Add temporary note for macOS users informing them that they cannot complete the AITK tutorial.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```
