### PR TITLE
Fix incorrect npm script name in documentation

### DIFF
--- a/03-GettingStarted/01-first-server/README.md
+++ b/03-GettingStarted/01-first-server/README.md
@@ -1034,7 +1034,7 @@ The inspector is a great tool that can start up your server and lets you interac
 npx @modelcontextprotocol/inspector node build/index.js
 ```
 
-or add it to your *package.json* like so: `"inspector": "npx @modelcontextprotocol/inspector node build/index.js"` and then run `npm run inspect`
+or add it to your *package.json* like so: `"inspector": "npx @modelcontextprotocol/inspector node build/index.js"` and then run `npm run inspector`
 
 Python wraps a Node.js tool called inspector. It's possible to call said tool like so:
 

--- a/03-GettingStarted/02-client/README.md
+++ b/03-GettingStarted/02-client/README.md
@@ -513,7 +513,7 @@ To run the client, type the following command in the terminal:
 Add the following entry to your "scripts" section in *package.json*:
 
 ```json
-"client": "tsx && node build/client.js"
+"client": "tsc && node build/client.js"
 ```
 
 ```sh


### PR DESCRIPTION
# Purpose

Describe the intention of the changes being proposed. What problem does it solve or functionality does it add?

Fixed a mistake in the documentation where the npm script name was incorrectly listed as inspect.

1. Updated to` npm run inspector` to match the corresponding entry in package.json:

```
"inspector": "npx @modelcontextprotocol/inspector node build/index.js"
```
2. fix script `"client": "tsx && node build/client.js"` to `"client": "tsc && node build/client.js"`

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
