### PR TITLE
Fixed Typo in readme.md issue #278

### DIFF
--- a/03-GettingStarted/01-first-server/solution/python/README.md
+++ b/03-GettingStarted/01-first-server/solution/python/README.md
@@ -11,7 +11,7 @@ python -m venv venv
 ## -1- Activate the virtual environment
 
 ```bash
-venv\Scrips\activate
+venv\Scripts\activate
 ```
 
 ## -2- Install the dependencies


### PR DESCRIPTION
# Purpose

This PR fixes a minor typo in the README.md file. The activation command for the Python virtual environment on Windows was incorrectly written as:

venv/Scrips/activate

It has been corrected to:

venv/Scripts/activate

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x ] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```
