### PR TITLE
docs: fix typos and improve clarity in documentation

### DIFF
--- a/00-Introduction/README.md
+++ b/00-Introduction/README.md
@@ -16,7 +16,7 @@ The **Model Context Protocol (MCP)** is an **open, standardized interface** that
 
 ## **🎯 Why Standardization in AI Matters**
 
-As generative AI applications become more complex, it's essential to adopt standards that ensure **scalability, extensibility**, **maintainability** and **avoiding vendor lock in**. MCP addresses these needs by:
+As generative AI applications become more complex, it's essential to adopt standards that ensure **scalability, extensibility, maintainability,** and **avoiding vendor lock-in**. MCP addresses these needs by:
 
 - Unifying model-tool integrations
 - Reducing brittle, one-off custom solutions

--- a/01-CoreConcepts/README.md
+++ b/01-CoreConcepts/README.md
@@ -119,7 +119,7 @@ Prompts in the Model Context Protocol (MCP) include various pre-defined template
 - **Pre-defined Interaction Patterns**: Standardized sequences of actions and responses that facilitate consistent and efficient communication.
 - **Specialized Conversation Templates**: Customizable templates tailored for specific types of conversations, ensuring relevant and contextually appropriate interactions.
 
-A prompt template can look like so:
+A prompt template could look like this:
 
 ```markdown
 Generate a product slogan based on the following {{product}} with the following {{keywords}}

--- a/09-CaseStudy/apimsample.md
+++ b/09-CaseStudy/apimsample.md
@@ -154,7 +154,7 @@ Let's see how, to add the MCP server in Visual Studio Code:
 
 Now we're all set up in either settings or in *.vscode/mcp.json*. Let's try it out. 
 
-Theres should be a Tools icon like so, where the exposed tools from your server are listed:
+There should be a Tools icon like so, where the exposed tools from your server are listed:
 
 ![Tools from the server](https://learn.microsoft.com/en-us/azure/api-management/media/export-rest-mcp-server/tools-button-visual-studio-code.png)
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Our team produces other courses! Check out:
 - [ML for Beginners](https://aka.ms/ml-beginners?WT.mc_id=academic-105485-koreyst)
 - [Data Science for Beginners](https://aka.ms/datascience-beginners?WT.mc_id=academic-105485-koreyst)
 - [AI for Beginners](https://aka.ms/ai-beginners?WT.mc_id=academic-105485-koreyst)
-- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101??WT.mc_id=academic-96948-sayoung)
+- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101?WT.mc_id=academic-96948-sayoung)
 - [Web Dev for Beginners](https://aka.ms/webdev-beginners?WT.mc_id=academic-105485-koreyst)
 - [IoT for Beginners](https://aka.ms/iot-beginners?WT.mc_id=academic-105485-koreyst)
 - [XR Development for Beginners](https://github.com/microsoft/xr-development-for-beginners?WT.mc_id=academic-105485-koreyst)


### PR DESCRIPTION
Fixes minor typos and improves clarity across 4 documentation files:

- Fix grammar and punctuation in standardization benefits list
- Fix double question marks in Cybersecurity link  
- Improve prompt template description clarity
- Fix typo "Theres" → "There"

No functional changes - documentation improvements only.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```