### PR TITLE
fix content insertion

### DIFF
--- a/01-CoreConcepts/README.md
+++ b/01-CoreConcepts/README.md
@@ -4,7 +4,8 @@
 
 _(Click the image above to view video of this lesson)_
 
-The [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) is a powerful, standardized framework that optimizes communication between Large Language Models (LLMs) and external tools, applications, and data sources. This guide will walk you through the core concepts of MCP, ensuring you understand its client-server architecture, essential components, communication mechanics, and implementation best practices.
+The [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) is a powerful, standardized framework that optimizes communication between Large Language Models (LLMs) and external tools, applications, and data sources. 
+This guide will walk you through the core concepts of MCP. You will learn about its client-server architecture, essential components, communication mechanics, and implementation best practices.
 
 - **Explicit User Consent**: All data access and operations require explicit user approval before execution. Users must clearly understand what data will be accessed and what actions will be performed, with granular control over permissions and authorizations.
 

--- a/01-CoreConcepts/README.md
+++ b/01-CoreConcepts/README.md
@@ -4,7 +4,9 @@
 
 _(Click the image above to view video of this lesson)_
 
-The [Model Context Protocol (MCP)](https://gi- **Explicit User Consent**: All data access and operations require explicit user approval before execution. Users must clearly understand what data will be accessed and what actions will be performed, with granular control over permissions and authorizations.
+The [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) is a powerful, standardized framework that optimizes communication between Large Language Models (LLMs) and external tools, applications, and data sources. This guide will walk you through the core concepts of MCP, ensuring you understand its client-server architecture, essential components, communication mechanics, and implementation best practices.
+
+- **Explicit User Consent**: All data access and operations require explicit user approval before execution. Users must clearly understand what data will be accessed and what actions will be performed, with granular control over permissions and authorizations.
 
 - **Data Privacy Protection**: User data is only exposed with explicit consent and must be protected by robust access controls throughout the entire interaction lifecycle. Implementations must prevent unauthorized data transmission and maintain strict privacy boundaries.
 
@@ -17,7 +19,7 @@ The [Model Context Protocol (MCP)](https://gi- **Explicit User Consent**: All da
 - **Permission Management**: Implement fine-grained permission systems that allow users to control which servers, tools, and resources are accessible
 - **Authentication & Authorization**: Use secure authentication methods (OAuth, API keys) with proper token management and expiration  
 - **Input Validation**: Validate all parameters and data inputs according to defined schemas to prevent injection attacks
-- **Audit Logging**: Maintain comprehensive logs of all operations for security monitoring and compliancecom/modelcontextprotocol) is a powerful, standardized framework that optimizes communication between Large Language Models (LLMs) and external tools, applications, and data sources. This guide will walk you through the core concepts of MCP, ensuring you understand its client-server architecture, essential components, communication mechanics, and implementation best practices.
+- **Audit Logging**: Maintain comprehensive logs of all operations for security monitoring and compliance
 
 ## Overview
 


### PR DESCRIPTION
PR #320 inserted new content into the middle of a URL instead of after its paragraph.

# Purpose

Fix previous edit in [01-CoreConcepts/README.md](https://github.com/microsoft/mcp-for-beginners/blob/main/01-CoreConcepts/README.md)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[ ] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
