### PR TITLE
Update Personal Access Token notes to include Models permission

### DIFF
--- a/03-GettingStarted/03-llm-client/README.md
+++ b/03-GettingStarted/03-llm-client/README.md
@@ -40,8 +40,8 @@ Creating a GitHub token is a straightforward process. Here’s how you can do it
 
 - Go to GitHub Settings – Click on your profile picture in the top right corner and select Settings.
 - Navigate to Developer Settings – Scroll down and click on Developer Settings.
-- Select Personal Access Tokens – Click on Personal access tokens and then Generate new token.
-- Configure Your Token – Add a note for reference, set an expiration date, and select the necessary scopes (permissions).
+- Select Personal Access Tokens – Click on Fine-grained tokens and then Generate new token.
+- Configure Your Token – Add a note for reference, set an expiration date, and select the necessary scopes (permissions). In this case be sure to add the Models permission.
 - Generate and Copy the Token – Click Generate token, and make sure to copy it immediately, as you won’t be able to see it again.
 
 ### -1- Connect to server


### PR DESCRIPTION
## Summary

I've updated the `Authentication using GitHub Personal Access Token` section in the `03-GettingStarted/03-llm-client/README.md` file. I found it wasn't clear which permissions to add and noted people need to include the `Models` permission. 

I also updated the notes to reference `Fine-grained tokens` based on the GitHub options available in the screenshot below.

<img width="414" height="264" alt="image" src="https://github.com/user-attachments/assets/af9f489a-4068-4862-a75d-4e55c43db838" />