### PR TITLE
Update README.md

### DIFF
--- a/03-GettingStarted/01-first-server/README.md
+++ b/03-GettingStarted/01-first-server/README.md
@@ -415,8 +415,8 @@ Open the *package.json* file and replace the content with the following to ensur
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "tsc && node ./build/index.js",
-    "build": "tsc && node ./build/index.js"
+    "build": "tsc",
+    "start": "npm run build && node ./build/index.js",
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Fix the duplication on the "start" and "build" npm scripts. Now the "build" only builds, and the "start" builds and launches the server (while reusing the "build" script).