### PR TITLE
bug fix: chp3.03, python tutorial missing one line of code

### DIFF
--- a/03-GettingStarted/03-llm-client/README.md
+++ b/03-GettingStarted/03-llm-client/README.md
@@ -503,6 +503,7 @@ Next step after listing server capabilities is to convert them into a format tha
 1. Next, let's update our client code to leverage this function like so:
 
     ```python
+    functions = []
     for tool in tools.tools:
         print("Tool: ", tool.name)
         print("Tool", tool.inputSchema["properties"])


### PR DESCRIPTION
**Summary**
In `03-GettingStarted/03-llm-client/README.md`, under the section **“3 – Convert server capabilities to LLM tools”**, the Python tutorial is missing the definition of the parameter `functions`.
This PR adds the missing line:

```python
functions = []
```

This is a documentation-only fix.
