### PR TITLE
Fix python solution in module 3.5

### DIFF
--- a/03-GettingStarted/05-stdio-server/solution/python/server.py
+++ b/03-GettingStarted/05-stdio-server/solution/python/server.py
@@ -108,7 +108,7 @@ async def main():
     
     try:
         # Use stdio transport - this is the recommended approach
-        async with stdio_server(server) as (read_stream, write_stream):
+        async with stdio_server() as (read_stream, write_stream):
             logger.info("Server connected via stdio transport")
             await server.run(
                 read_stream,


### PR DESCRIPTION
Fixed errors in python solution for module 3.5: stdio server

ToDo
- [ ] update module instructions [README](https://github.com/microsoft/mcp-for-beginners/blob/main/03-GettingStarted/05-stdio-server/README.md) to match solution: `Server` does not have a `tool()` method.