### PR TITLE
📝 nit - change Python asyncio entry point from run() to main()

### DIFF
--- a/03-GettingStarted/02-client/README.md
+++ b/03-GettingStarted/02-client/README.md
@@ -239,7 +239,7 @@ async def run():
 if __name__ == "__main__":
     import asyncio
 
-    asyncio.run(run())
+    asyncio.run(main())
 ```
 
 In the preceding code we've:


### PR DESCRIPTION
Updated the entry point of the asyncio application from 'run()' to 'main()' in the markdown description.