### PR TITLE
Fix: Typo in 03-GettingStarted/08-testing README

### DIFF
--- a/03-GettingStarted/08-testing/README.md
+++ b/03-GettingStarted/08-testing/README.md
@@ -24,7 +24,7 @@ MCP provides tools to help you test and debug your servers:
 
 ### Using MCP Inspector
 
-We've describes the usage of this tool in previous lessons but let's talk about it a bit at high level. It's a tool built in Node.js and you can use it by calling the `npx` executable which will download and install the tool itself temporarily and will clean itself up once it's done running your request.
+We've described the usage of this tool in previous lessons but let's talk about it a bit at high level. It's a tool built in Node.js and you can use it by calling the `npx` executable which will download and install the tool itself temporarily and will clean itself up once it's done running your request.
 
 The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) helps you:
 


### PR DESCRIPTION
In the **Using MCP Inspector** section of 03-GettingStarted/08-testing/README.md,  there is a typo:

Current: "We've describes the usage of this tool..."
Correct: "We've described the usage of this tool..."


<img width="973" height="170" alt="Screenshot 2026-03-07 091606" src="https://github.com/user-attachments/assets/4e0e90a7-3d9f-4bfa-8461-3ad794470311" />
