### PR TITLE
Fix: Typos in module 03-GettingStarted/10-Advanced

### DIFF
--- a/03-GettingStarted/10-advanced/README.md
+++ b/03-GettingStarted/10-advanced/README.md
@@ -46,7 +46,7 @@ The point being is that you explicitly add each tool, resource or prompt that yo
 
 ### Low-level server approach
 
-However, when you use the low-level server approach you need to think about differently. Instead of registering each tool, you instead create two handlers per feature type (tools, resources or prompts). So for example tools then only have two functions like so:
+However, when you use the low-level server approach you need to think about it differently. Instead of registering each tool, you instead create two handlers per feature type (tools, resources or prompts). So for example tools then only have two functions like so:
 
 - Listing all tools. One function would be responsible for all attempts to list tools.
 - handle calling all tools. Here also, there's only one function handling calls to a tool
@@ -177,7 +177,7 @@ So far, you've seen how all your registrations to add tools, resources and promp
 
 ### Create a feature
 
-To create a feature, we will need to create a file for that feature and make sure it has the mandatory fields requred of that feature. Which fields differ a bit between tools, resources and prompts.
+To create a feature, we will need to create a file for that feature and make sure it has the mandatory fields required of that feature. Which fields differ a bit between tools, resources and prompts.
 
 **Python**
 
@@ -442,7 +442,7 @@ import { z } from 'zod';
 export const MathInputSchema = z.object({ a: z.number(), b: z.number() });
 ```
 
-Great, let's procced to handle the listing of our tools next.
+Great, let's proceed to handle the listing of our tools next.
 
 ### -3- Handle tool listing
 


### PR DESCRIPTION
Fixes the following typos in module 03-GettingStarted/10-Advanced:

- **Before**: _think about differently_ -> **After**: _think about it differently_
- **Before**: _requred_ -> **After**: _required_
- **Before**: _procced_ -> **After**: _proceed_