### PR TITLE
Fix typos in 03-GettingStarted/14-sampling README.md

### DIFF
--- a/03-GettingStarted/14-sampling/README.md
+++ b/03-GettingStarted/14-sampling/README.md
@@ -71,13 +71,13 @@ Ok, now we have a mile high view of a credible scenario, let's talk about the sa
 }
 ```
 
-There's a few things here worth calling out:
+There're a few things here worth calling out:
 
 - Prompt, under content -> text, is our prompt that is an instruction for the LLM to summarize blog post content.
 
 - **modelPreferences**. This section is just that, a preference, a recommendation of what configuration to use with the LLM. The user can choose whether to go with these recommendations or change them. In this case there are recommendations on model to use and speed and intelligence priority.
-- **systemPrompt**, this is your normal system prompt that gives your LLM a personaly and contains guidance instructions.
-- **maxTokens**, this is another property that's used to say how many tokens is recommended to use for this task.
+- **systemPrompt**, this is your normal system prompt that gives your LLM a personality and contains guidance instructions.
+- **maxTokens**, this is another property that's used to say how many tokens are recommended to use for this task.
 
 ### Sampling response
 
@@ -140,7 +140,7 @@ Sampling messages aren't constrained to just text but you can also send, images 
 
 ## How to Configure Sampling in the Client
 
-> Note: if you're only building building a server, you don't need to do much here.
+> Note: if you're only building a server, you don't need to do much here.
 
 In a client, you need to specify the following feature like so:
 
@@ -160,7 +160,7 @@ Let's code a sampling server together, we will need to do the following:
 
 1. Create a tool on the Server.
 1. Said tool should create a sampling request
-1. Tool should wait for the clients sampling request to be answered.
+1. Tool should wait for the client's sampling request to be answered.
 1. Then the tool result should be produced.
 
 Let's see the code step by step:
@@ -332,9 +332,9 @@ To test this out in Visual Studio Code, do the following:
 
 In this assignment, you will build a slightly different Sampling namely a sampling integration that supports generating a product description. Here's your scenario:
 
-**Scenario**: The back office worker at an e-commerce needs help, it takes way too much time to generate product descriptions. Therefore, you are to build a solution where you can call a tool "create_product" with "title" and "keywords" as argument and it should produce a complete product including a "description" field that should be populated by a client's LLM.
+**Scenario**: The back office worker at an e-commerce needs help, it takes way too much time to generate product descriptions. Therefore, you are to build a solution where you can call a tool "create_product" with "title" and "keywords" as arguments and it should produce a complete product including a "description" field that should be populated by a client's LLM.
 
-TIP: use what you learned earlier how to construct this server and its tool using a sampling request.
+TIP: use what you learned earlier to construct this server and its tool using a sampling request.
 
 ## Solution
 

--- a/03-GettingStarted/14-sampling/README.md
+++ b/03-GettingStarted/14-sampling/README.md
@@ -71,7 +71,7 @@ Ok, now we have a mile high view of a credible scenario, let's talk about the sa
 }
 ```
 
-There're a few things here worth calling out:
+There are a few things here worth calling out:
 
 - Prompt, under content -> text, is our prompt that is an instruction for the LLM to summarize blog post content.
 

--- a/03-GettingStarted/14-sampling/README.md
+++ b/03-GettingStarted/14-sampling/README.md
@@ -18,7 +18,7 @@ In this chapter, we will:
 
 ## What is Sampling and why use it?
 
-Sampling is an davanced features that works in the following way:
+Sampling is an advanced feature that works in the following way:
 
 ```mermaid
 sequenceDiagram


### PR DESCRIPTION
Fixes typos in 03-GettingStarted/14-sampling README.md, such as:

-  "...gives your LLM a personaly ..."  ->  "... gives your LLM a personality ..."

- "... if you're only building building a server ..."  ->  "... if you're only building a server ..."