### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/03-GettingStarted/15-mcp-apps/ext-apps/examples/basic-host/package.json
+++ b/03-GettingStarted/15-mcp-apps/ext-apps/examples/basic-host/package.json
@@ -15,7 +15,8 @@
     "@modelcontextprotocol/sdk": "^1.24.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/03-GettingStarted/15-mcp-apps/ext-apps/examples/basic-host/serve.ts
+++ b/03-GettingStarted/15-mcp-apps/ext-apps/examples/basic-host/serve.ts
@@ -12,6 +12,7 @@
 
 import express from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import type { AddressInfo } from "net";
@@ -178,6 +179,15 @@ function buildCspHeader(csp?: McpUiResourceCsp): string {
 
   return directives.join("; ");
 }
+
+const sandboxRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+sandboxApp.use(sandboxRateLimiter);
 
 // Serve sandbox.html with CSP from query params
 sandboxApp.get(["/", "/sandbox.html"], (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/mcp-for-beginners/security/code-scanning/3](https://github.com/microsoft/mcp-for-beginners/security/code-scanning/3)

Add `express-rate-limit` middleware and apply it to the sandbox server before the `GET /` and `/sandbox.html` handler. This is the least invasive fix that preserves functionality while introducing request throttling. A conservative default (for example, 100 requests per 15 minutes per IP) is standard and aligns with CodeQL recommendations.

In `03-GettingStarted/15-mcp-apps/ext-apps/examples/basic-host/serve.ts`:
1. Add an import for `express-rate-limit`.
2. Define a sandbox-specific limiter near app setup/constants.
3. Apply it via `sandboxApp.use(sandboxRateLimiter);` before the sandbox route definition at line ~183.

No route logic changes are required; `sendFile` behavior remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
