### PR TITLE
fix: correct object literal syntax in example

### DIFF
--- a/03-GettingStarted/10-advanced/README.md
+++ b/03-GettingStarted/10-advanced/README.md
@@ -84,12 +84,12 @@ server.setRequestHandler(ListToolsRequestSchema, async (request) => {
   // Return the list of registered tools
   return {
     tools: [{
-        name="add",
-        description="Add two numbers",
-        inputSchema={
+        name: "add",
+        description: "Add two numbers",
+        inputSchema: {
             "type": "object",
             "properties": {
-                "a": {"type": "number", "description": "number to add"}, 
+                "a": {"type": "number", "description": "number to add"},
                 "b": {"type": "number", "description": "number to add"}
             },
             "required": ["query"],
@@ -530,7 +530,7 @@ async def handle_call_tool(
 
     return [
         types.TextContent(type="text", text=str(result))
-    ] 
+    ]
 ```
 
 Here's what goes on:


### PR DESCRIPTION
This PR includes the following improvement:

- The tool definition uses invalid object syntax (= instead of :), which breaks TypeScript parsing.