### PR TITLE
fix: correct typos and grammar in Spanish translation

### DIFF
--- a/translations/es/00-Introduction/README.md
+++ b/translations/es/00-Introduction/README.md
@@ -215,7 +215,7 @@ graph TD
         KnowledgeB[Conocimiento]
         ToolsB[Herramientas]
     end
-```El Conector Universal permite que los servidores MCP se comuniquen y compartan capacidades entre sí, permitiendo que ServerA delegue tareas a ServerB o acceda a sus herramientas y conocimiento. Esto federara herramientas y datos entre servidores, apoyando arquitecturas de agentes escalables y modulares. Debido a que MCP estandariza la exposición de herramientas, los agentes pueden descubrir y enrutar solicitudes dinámicamente entre servidores sin integraciones codificadas.
+```El Conector Universal permite que los servidores MCP se comuniquen y compartan capacidades entre sí, permitiendo que ServerA delegue tareas a ServerB o acceda a sus herramientas y conocimiento. Esto federará herramientas y datos entre servidores, apoyando arquitecturas de agentes escalables y modulares. Debido a que MCP estandariza la exposición de herramientas, los agentes pueden descubrir y enrutar solicitudes dinámicamente entre servidores sin integraciones codificadas.
 
 Federación de herramientas y conocimiento: Se puede acceder a herramientas y datos a través de servidores, lo que habilita arquitecturas agenticas más escalables y modulares.
 

--- a/translations/es/01-CoreConcepts/README.md
+++ b/translations/es/01-CoreConcepts/README.md
@@ -677,7 +677,7 @@ Las tareas envuelven solicitudes estándar MCP para habilitar patrones de ejecuc
 - **Participantes**: El ecosistema incluye anfitriones (aplicaciones IA), clientes (conectores de protocolo) y servidores (proveedores de capacidades)  
 - **Mecanismos de transporte**: Soporta STDIO (local) y HTTP transmisible con SSE opcional (remoto)  
 - **Primitivas centrales**: Los servidores exponen herramientas (funciones ejecutables), recursos (fuentes de datos) y mensajes predefinidos (plantillas)  
-- **Primitivas de cliente**: Los servidores pueden solicitar muestreos (completaciones LLM con soporte de llamadas a herramientas), elicitud (entrada usuario incluyendo modo URL), límites (delimitadores del sistema de archivos) y registro desde clientes  
+- **Primitivas de cliente**: Los servidores pueden solicitar muestreos (completaciones LLM con soporte de llamadas a herramientas), elicitación (entrada usuario incluyendo modo URL), límites (delimitadores del sistema de archivos) y registro desde clientes  
 - **Funciones experimentales**: Las tareas proporcionan envoltorios duraderos para operaciones de larga duración  
 - **Base del protocolo**: Construido sobre JSON-RPC 2.0 con versionado basado en fechas (actual: 2025-11-25)  
 - **Capacidades en tiempo real**: Soporta notificaciones para actualizaciones dinámicas y sincronización en tiempo real  

--- a/translations/es/02-Security/README.md
+++ b/translations/es/02-Security/README.md
@@ -71,7 +71,7 @@ La [Guía de Seguridad MCP Azure OWASP](https://microsoft.github.io/mcp-azure-se
 | **MCP06** | Inyección de prompts vía cargas contextuales | Azure AI Content Safety, Prompt Shields |
 | **MCP07** | Autenticación y autorización insuficientes | Azure Entra ID, OAuth 2.1 con PKCE |
 | **MCP08** | Falta de auditoría y telemetría | Azure Monitor, Application Insights |
-| **MCP09** | Servidores MCP "ombra" | Gobernanza en API Center, aislamiento de red |
+| **MCP09** | Servidores MCP "sombra" | Gobernanza en API Center, aislamiento de red |
 | **MCP10** | Inyección de contexto y sobre-exposición | Clasificación de datos, exposición mínima |
 
 ### Evolución de Autenticación MCP

--- a/translations/es/README.md
+++ b/translations/es/README.md
@@ -55,7 +55,7 @@ Sigue estos pasos para empezar a usar estos recursos:
 
 Piensa en MCP como un traductor universal para aplicaciones de IA, así como los puertos USB permiten conectar cualquier dispositivo a tu computadora, MCP permite que los modelos de IA se conecten a cualquier herramienta o servicio de manera estandarizada. Ya sea que estés construyendo tu primer chatbot o trabajando en flujos de trabajo complejos de IA, entender MCP te dará el poder de crear aplicaciones más capaces y flexibles.
 
-Este currículo está diseñado con paciencia y cuidado para tu proceso de aprendizaje. Comenzaremos con conceptos simples que ya conoces y gradualmente construiremos tu experiencia con práctica práctica utilizando tu lenguaje de programación favorito. Cada paso incluye explicaciones claras, ejemplos prácticos y mucho ánimo en el camino.
+Este currículo está diseñado con paciencia y cuidado para tu proceso de aprendizaje. Comenzaremos con conceptos simples que ya conoces y gradualmente construiremos tu experiencia con experiencia práctica utilizando tu lenguaje de programación favorito. Cada paso incluye explicaciones claras, ejemplos prácticos y mucho ánimo en el camino.
 
 Al completar este viaje, tendrás la confianza para construir tus propios servidores MCP, integrarlos con plataformas populares de IA y entender cómo esta tecnología está remodelando el futuro del desarrollo de IA. ¡Comencemos esta emocionante aventura juntos!
 


### PR DESCRIPTION
## Summary
Corrects Spanish translation errors:

- Fix doubled word: "práctica práctica" → "experiencia práctica" in README
- Fix missing letter: "ombra" → "sombra" in Security lesson
- Fix missing accent: "federara" → "federará" in Introduction
- Fix typo: "elicitud" → "elicitación" in Core Concepts

## Testing
- Markdown-only changes, no code affected