### PR TITLE
Fix formatting of Co-op Translator disclaimer

### DIFF
--- a/translations/ja/05-AdvancedTopics/mcp-protocol-features/README.md
+++ b/translations/ja/05-AdvancedTopics/mcp-protocol-features/README.md
@@ -720,5 +720,5 @@ async def safe_query(query: str) -> str:
 
 <!-- CO-OP TRANSLATOR DISCLAIMER START -->
 **免責事項**：
-本書類はAI翻訳サービス「Co-op Translator」（https://github.com/Azure/co-op-translator）を利用して翻訳されました。正確性を期していますが、自動翻訳には誤りや不正確な部分が含まれる可能性があることをご承知ください。原文の言語による文書が権威ある正式な情報源とみなされます。重要な情報については、専門の人間による翻訳を推奨します。本翻訳の使用に起因する誤解や誤訳について、当方は一切の責任を負いかねます。
+本書類はAI翻訳サービス「[Co-op Translator](https://github.com/Azure/co-op-translator)」を利用して翻訳されました。正確性を期していますが、自動翻訳には誤りや不正確な部分が含まれる可能性があることをご承知ください。原文の言語による文書が権威ある正式な情報源とみなされます。重要な情報については、専門の人間による翻訳を推奨します。本翻訳の使用に起因する誤解や誤訳について、当方は一切の責任を負いかねます。
 <!-- CO-OP TRANSLATOR DISCLAIMER END -->


### PR DESCRIPTION
https://github.com/microsoft/mcp-for-beginners/blob/main/translations/ja/05-AdvancedTopics/mcp-protocol-features/README.md 

<img width="1094" height="339" alt="image" src="https://github.com/user-attachments/assets/46c59be4-b207-4304-825d-1acfaaf1e825" />

related https://github.com/Azure/co-op-translator/issues/363

#PingMSFTDocs