### PR TITLE
Fix MCP specification link in README

### DIFF
--- a/05-AdvancedTopics/mcp-realtimestreaming/README.md
+++ b/05-AdvancedTopics/mcp-realtimestreaming/README.md
@@ -608,7 +608,7 @@ Advanced exercise covering:
 
 ## Additional Resources
 
-- [Model Context Protocol Specification](https://github.com/modelcontextprotocol) - Official MCP specification and documentation
+- [Model Context Protocol Specification](https://modelcontextprotocol.io) - Official MCP specification and documentation
 - [Apache Kafka Documentation](https://kafka.apache.org/documentation/) - Learn about Kafka for stream processing
 - [Apache Pulsar](https://pulsar.apache.org/) - Unified messaging and streaming platform
 - [Streaming Systems: The What, Where, When, and How of Large-Scale Data Processing](https://www.oreilly.com/library/view/streaming-systems/9781491983867/) - Comprehensive book on streaming architectures


### PR DESCRIPTION
Updated the link for the Model Context Protocol Specification to the new URL.

https://github.com/microsoft/mcp-for-beginners/blob/main/05-AdvancedTopics/mcp-realtimestreaming/README.md

<img width="1165" height="182" alt="image" src="https://github.com/user-attachments/assets/d0e0d58b-56d3-462e-9830-6cd6b35ad9b8" />

#PingMSFTDocs