### PR TITLE
docs(security): update OWASP MCP Top 10 names and sherpa references

### DIFF
--- a/02-Security/README.md
+++ b/02-Security/README.md
@@ -50,9 +50,9 @@ The [MCP Security Summit Workshop](https://azure-samples.github.io/sherpa/) prov
 |------|-------|---------------------|
 | **Base Camp** | MCP fundamentals & authentication vulnerabilities | MCP01, MCP07 |
 | **Camp 1: Identity** | OAuth 2.1, Azure Managed Identity, Key Vault | MCP01, MCP02, MCP07 |
-| **Camp 2: Gateway** | API Management, Private Endpoints, governance | MCP02, MCP07, MCP09 |
-| **Camp 3: I/O Security** | Prompt injection, PII protection, content safety | MCP03, MCP05, MCP06 |
-| **Camp 4: Monitoring** | Log Analytics, dashboards, threat detection | MCP08 |
+| **Camp 2: Gateway** | API Management, Private Endpoints, governance | MCP02, MCP06, MCP07, MCP09 |
+| **Camp 3: I/O Security** | Prompt injection, PII protection, content safety | MCP03, MCP05, MCP06, MCP10 |
+| **Camp 4: Monitoring** | Log Analytics, dashboards, threat detection | MCP04, MCP08 |
 | **The Summit** | Red Team / Blue Team integration test | All |
 
 **Get Started**: [https://azure-samples.github.io/sherpa/](https://azure-samples.github.io/sherpa/)
@@ -66,11 +66,11 @@ The [OWASP MCP Azure Security Guide](https://microsoft.github.io/mcp-azure-secur
 | **MCP01** | Token Mismanagement & Secret Exposure | Azure Key Vault, Managed Identity |
 | **MCP02** | Privilege Escalation via Scope Creep | RBAC, Conditional Access |
 | **MCP03** | Tool Poisoning | Tool validation, integrity verification |
-| **MCP04** | Supply Chain Attacks | GitHub Advanced Security, dependency scanning |
+| **MCP04** | Software Supply Chain Attacks & Dependency Tampering | GitHub Advanced Security, dependency scanning |
 | **MCP05** | Command Injection & Execution | Input validation, sandboxing |
-| **MCP06** | Prompt Injection via Contextual Payloads | Azure AI Content Safety, Prompt Shields |
+| **MCP06** | Intent Flow Subversion | Azure AI Content Safety, Prompt Shields |
 | **MCP07** | Insufficient Authentication & Authorization | Azure Entra ID, OAuth 2.1 with PKCE |
-| **MCP08** | Lack of Audit & Telemetry | Azure Monitor, Application Insights |
+| **MCP08** | Lack of Audit and Telemetry | Azure Monitor, Application Insights |
 | **MCP09** | Shadow MCP Servers | API Center governance, network isolation |
 | **MCP10** | Context Injection & Over-Sharing | Data classification, minimal exposure |
 
@@ -489,6 +489,7 @@ For comprehensive security guidance, refer to these specialized documents in thi
 - **[Azure Content Safety Implementation](./azure-content-safety-implementation.md)** - Practical implementation examples for Azure Content Safety integration  
 - **[MCP Security Controls 2025](./mcp-security-controls-2025.md)** - Latest security controls and techniques for MCP deployments
 - **[MCP Best Practices Quick Reference](./mcp-best-practices.md)** - Quick reference guide for essential MCP security practices
+- **[BlueHat 2026: Securing the future of AI](https://youtu.be/cVWB58kEt-Y?si=GXDduD8ztt5HLV8M)** - Securing MCP with defense-in-depth patterns from the Microsoft Security Response Center (MSRC)
 
 ### **Hands-On Security Training**
 

--- a/02-Security/README.md
+++ b/02-Security/README.md
@@ -489,7 +489,7 @@ For comprehensive security guidance, refer to these specialized documents in thi
 - **[Azure Content Safety Implementation](./azure-content-safety-implementation.md)** - Practical implementation examples for Azure Content Safety integration  
 - **[MCP Security Controls 2025](./mcp-security-controls-2025.md)** - Latest security controls and techniques for MCP deployments
 - **[MCP Best Practices Quick Reference](./mcp-best-practices.md)** - Quick reference guide for essential MCP security practices
-- **[BlueHat 2026: Securing the future of AI](https://youtu.be/cVWB58kEt-Y?si=GXDduD8ztt5HLV8M)** - Securing MCP with defense-in-depth patterns from the Microsoft Security Response Center (MSRC)
+- **[BlueHat 2026: Securing the future of AI: Securing MCP with defense in depth patterns](https://www.youtube.com/watch?v=cVWB58kEt-Y)** - Defense-in-depth patterns from the Microsoft Security Response Center (MSRC)
 
 ### **Hands-On Security Training**
 

--- a/02-Security/azure-content-safety-implementation.md
+++ b/02-Security/azure-content-safety-implementation.md
@@ -1,6 +1,6 @@
 # Implementing Azure Content Safety with MCP
 
-> **OWASP MCP Risk Addressed**: [MCP06 - Prompt Injection via Contextual Payloads](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
+> **OWASP MCP Risk Addressed**: [MCP06 - Intent Flow Subversion](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
 
 To strengthen MCP security against prompt injection, tool poisoning, and other AI-specific vulnerabilities, integrating Azure Content Safety is highly recommended. This implementation guide aligns with the [MCP Security Summit Workshop (Sherpa)](https://azure-samples.github.io/sherpa/) Camp 3: I/O Security.
 

--- a/02-Security/azure-content-safety.md
+++ b/02-Security/azure-content-safety.md
@@ -1,6 +1,6 @@
 # Advanced MCP Security with Azure Content Safety
 
-> **OWASP MCP Risk Addressed**: [MCP06 - Prompt Injection via Contextual Payloads](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
+> **OWASP MCP Risk Addressed**: [MCP06 - Intent Flow Subversion](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
 
 Azure Content Safety provides several powerful tools that can enhance the security of your MCP implementations. For hands-on implementation experience, see [MCP Security Summit Workshop (Sherpa)](https://azure-samples.github.io/sherpa/) Camp 3: I/O Security.
 

--- a/02-Security/mcp-security-controls-2025.md
+++ b/02-Security/mcp-security-controls-2025.md
@@ -144,7 +144,7 @@ Session Lifecycle:
 ## 4. **AI-Specific Security Controls**
 
 **OWASP MCP Risks Addressed**:
-- [MCP06 - Prompt Injection via Contextual Payloads](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
+- [MCP06 - Intent Flow Subversion](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp06-prompt-injection/)
 - [MCP03 - Tool Poisoning](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp03-tool-poisoning/)
 - [MCP05 - Command Injection & Execution](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp05-command-injection/)
 
@@ -282,7 +282,7 @@ Access Control:
 
 ## 7. **Supply Chain Security Controls**
 
-**OWASP MCP Risk Addressed**: [MCP04 - Supply Chain Attacks](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp04-supply-chain/)
+**OWASP MCP Risk Addressed**: [MCP04 - Software Supply Chain Attacks & Dependency Tampering](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp04-supply-chain/)
 
 ### **Dependency Verification**
 
@@ -325,7 +325,7 @@ AI Components:
 
 ## 8. **Monitoring & Detection Controls**
 
-**OWASP MCP Risk Addressed**: [MCP08 - Lack of Audit & Telemetry](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp08-telemetry/)
+**OWASP MCP Risk Addressed**: [MCP08 - Lack of Audit and Telemetry](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp08-telemetry/)
 
 ### **Security Information and Event Management (SIEM)**
 


### PR DESCRIPTION
I am one of the maintainers for Sherpa Workshop, we have had a rehaul w.r.t the updates with OWASP top 10 MCP naming changes. This PR is for the same.

I have also added my MSRC BlueHat 2026 talk on MCP Security as additional reference material.

**Summary**

This pull request updates the MCP security documentation to reflect recent changes in terminology and risk definitions, and adds a new reference for advanced AI security. The main focus is on aligning the documentation with the latest OWASP MCP risk names and descriptions, especially for MCP04, MCP06, and MCP08, and ensuring consistency across workshop materials and security control guides.

**Terminology and Risk Definition Updates:**

* Updated MCP06 references from "Prompt Injection via Contextual Payloads" to "Intent Flow Subversion" across all documentation, including `azure-content-safety.md`, `azure-content-safety-implementation.md`, and `mcp-security-controls-2025.md`. [[1]](diffhunk://#diff-4f7cdf39b76b1a74b70bbef6dcf52744f1b152685ccbc62c272a1555f3baaa56L3-R3) [[2]](diffhunk://#diff-77792a96f244e7163de65d65e9de3d5c8a7fc7c7ac9c34fad15fe8971cda0b2bL3-R3) [[3]](diffhunk://#diff-02a4976d1d7a798dbbb346d2cef601d6c6875c68d185bc9c9281d46e75359bf4L147-R147)
* Updated MCP04 references from "Supply Chain Attacks" to "Software Supply Chain Attacks & Dependency Tampering" in risk tables and security controls. [[1]](diffhunk://#diff-f69a466f77344f7888c0e61b8a2a63ac8bd34ec24dc830418404fca2fc12dd66L69-R73) [[2]](diffhunk://#diff-02a4976d1d7a798dbbb346d2cef601d6c6875c68d185bc9c9281d46e75359bf4L285-R285)
* Updated MCP08 references from "Lack of Audit & Telemetry" to "Lack of Audit and Telemetry" for consistency. [[1]](diffhunk://#diff-f69a466f77344f7888c0e61b8a2a63ac8bd34ec24dc830418404fca2fc12dd66L69-R73) [[2]](diffhunk://#diff-02a4976d1d7a798dbbb346d2cef601d6c6875c68d185bc9c9281d46e75359bf4L328-R328)

**Workshop and Reference Material Enhancements:**

* Revised workshop camp and risk mappings to match the new risk definitions and added MCP06, MCP07, MCP09, and MCP10 where appropriate in `README.md`.
* Added a new external reference to "BlueHat 2026: Securing the future of AI" to the list of security resources.