### PR TITLE
Add missing README for the Rust LLM client solution

### DIFF
--- a/03-GettingStarted/03-llm-client/solution/rust/README.md
+++ b/03-GettingStarted/03-llm-client/solution/rust/README.md
@@ -1,0 +1,31 @@
+# Running this sample
+
+This is the Rust solution for the LLM client sample. You need a Rust toolchain installed; see the [official install guide](https://www.rust-lang.org/tools/install).
+
+The client calls a model through the GitHub Models inference endpoint (`https://models.github.ai/inference/chat`) and reads your token from the `OPENAI_API_KEY` environment variable.
+
+## -0- Set your API key
+
+```bash
+# zsh/bash
+export OPENAI_API_KEY="{{YOUR_GITHUB_TOKEN}}"
+```
+
+```powershell
+# PowerShell
+$env:OPENAI_API_KEY = "{{YOUR_GITHUB_TOKEN}}"
+```
+
+## -1- Build the sample
+
+```bash
+cargo build
+```
+
+## -2- Run the sample
+
+```bash
+cargo run
+```
+
+The client starts the calculator MCP server, lists its tools, and uses the model (`openai/gpt-5-mini`) to call the `add` tool. You should see output that lists the available tools and prints the result of the tool call.

--- a/03-GettingStarted/03-llm-client/solution/rust/README.md
+++ b/03-GettingStarted/03-llm-client/solution/rust/README.md
@@ -27,4 +27,4 @@ cargo build
 cargo run
 ```
 
-The client starts the calculator MCP server, lists its tools, and uses the model (`openai/gpt-5-mini`) to call the `add` tool. You should see output that lists the available tools and prints the result of the tool call.
+The client starts the calculator MCP server, fetches its tool list, and uses the model (`openai/gpt-5-mini`) to call the `add` tool. You should see output indicating the tool call (for example, "Calling tool: add") and the result of that call.

--- a/03-GettingStarted/03-llm-client/solution/rust/README.md
+++ b/03-GettingStarted/03-llm-client/solution/rust/README.md
@@ -2,19 +2,18 @@
 
 This is the Rust solution for the LLM client sample. You need a Rust toolchain installed; see the [official install guide](https://www.rust-lang.org/tools/install).
 
-The client calls a model through the GitHub Models inference endpoint (`https://models.github.ai/inference/chat`) and reads your token from the `OPENAI_API_KEY` environment variable.
+The client calls a model through the GitHub Models inference endpoint (`https://models.github.ai/inference/chat`) and reads your GitHub personal access token (PAT) from the `OPENAI_API_KEY` environment variable.
 
-## -0- Set your API key
+> [!NOTE]
+> Other solutions in this repo use `GITHUB_TOKEN`. For Rust, set `OPENAI_API_KEY` to the same value to match the OpenAI client configuration.
 
-```bash
-# zsh/bash
-export OPENAI_API_KEY="{{YOUR_GITHUB_TOKEN}}"
-```
+## -0- Set your GitHub token
 
-```powershell
-# PowerShell
-$env:OPENAI_API_KEY = "{{YOUR_GITHUB_TOKEN}}"
-```
+    # zsh/bash
+    export OPENAI_API_KEY="{{YOUR_GITHUB_PAT}}"
+
+    # PowerShell
+    $env:OPENAI_API_KEY = "{{YOUR_GITHUB_PAT}}"
 
 ## -1- Build the sample
 

--- a/03-GettingStarted/03-llm-client/solution/rust/README.md
+++ b/03-GettingStarted/03-llm-client/solution/rust/README.md
@@ -9,11 +9,15 @@ The client calls a model through the GitHub Models inference endpoint (`https://
 
 ## -0- Set your GitHub token
 
-    # zsh/bash
-    export OPENAI_API_KEY="{{YOUR_GITHUB_PAT}}"
+```bash
+# zsh/bash
+export OPENAI_API_KEY="{{YOUR_GITHUB_PAT}}"
+```
 
-    # PowerShell
-    $env:OPENAI_API_KEY = "{{YOUR_GITHUB_PAT}}"
+```powershell
+# PowerShell
+$env:OPENAI_API_KEY = "{{YOUR_GITHUB_PAT}}"
+```
 
 ## -1- Build the sample
 


### PR DESCRIPTION
The runtime list in `03-GettingStarted/03-llm-client/solution/README.md` links `[Rust](./rust/README.md)`, but the Rust solution folder has no `README.md` (only `Cargo.toml`, `Cargo.lock`, and `src/`), so that link is broken while the other four languages (TypeScript, Python, .NET, Java) each have one.

This adds `rust/README.md` following the same structure as the sibling solution READMEs. The run steps are grounded in `rust/src/main.rs`: the client reads the token from `OPENAI_API_KEY`, targets the GitHub Models endpoint `https://models.github.ai/inference/chat`, and uses the `openai/gpt-5-mini` model. This fixes the broken link and completes the per-language solution docs. Documentation only.