### PR TITLE
Fix typos in getting started lessons

### DIFF
--- a/03-GettingStarted/04-vscode/README.md
+++ b/03-GettingStarted/04-vscode/README.md
@@ -19,7 +19,7 @@ By the end of this lesson, you will be able to:
 You can control your MCP server in two different ways:
 
 - User interface, you will see how this is done later in this chapter.
-- Terminal, it's possible to control things from the terminal using the `code` exectuable:
+- Terminal, it's possible to control things from the terminal using the `code` executable:
 
   To add an MCP server to your user profile, use the --add-mcp command line option, and provide the JSON server configuration in the form {\"name\":\"server-name\",\"command\":...}.
 

--- a/03-GettingStarted/07-aitk/README.md
+++ b/03-GettingStarted/07-aitk/README.md
@@ -157,7 +157,7 @@ You will run the calculator MCP server on your local dev machine via the **Agent
 1. Click the **Run** button to generate the agent's response.
 1. Review the agent output. The model should conclude that you paid **$55**.
 1. Here's a breakdown of what should occur:
-    - The agent selects the **multiply** and **substract** tools to aid in the calculation.
+    - The agent selects the **multiply** and **subtract** tools to aid in the calculation.
     - The respective `a` and `b` values are assigned for the **multiply** tool.
     - The respective `a` and `b` values are assigned for the **subtract** tool.
     - The response from each tool is provided in the respective **Tool Response**.

--- a/03-GettingStarted/08-testing/README.md
+++ b/03-GettingStarted/08-testing/README.md
@@ -19,7 +19,7 @@ By the end of this lesson, you will be able to:
 MCP provides tools to help you test and debug your servers:
 
 - **MCP Inspector**: A command line tool that can be run both as a CLI tool and as a visual tool.
-- **Manual testing**: You can use a tool like curl to run web requests, but any tool capabable of running HTTP will do.
+- **Manual testing**: You can use a tool like curl to run web requests, but any tool capable of running HTTP will do.
 - **Unit testing**: It's possible to use your preferred testing framework to test the features of both server and client.
 
 ### Using MCP Inspector


### PR DESCRIPTION
Fix three documentation typos in the getting started lessons: executable, subtract, and capable.