### PR TITLE
improve text color contrast in MCP Architecture diagram

### DIFF
--- a/05-AdvancedTopics/mcp-realtimesearch/README.md
+++ b/05-AdvancedTopics/mcp-realtimesearch/README.md
@@ -161,11 +161,11 @@ graph TD
     RA -->|Research| Users((Users))
     Alerts -->|Notifications| Users
     KB <-->|Knowledge Access| API
-    
-    classDef sources fill:#f9f,stroke:#333,stroke-width:2px
-    classDef mcp fill:#bbf,stroke:#333,stroke-width:2px
-    classDef processing fill:#bfb,stroke:#333,stroke-width:2px
-    classDef apps fill:#fbb,stroke:#333,stroke-width:2px
+
+    classDef sources fill:#f9f,stroke:#333,stroke-width:2px,color:#4a004a
+    classDef mcp fill:#bbf,stroke:#333,stroke-width:2px,color:#00004a
+    classDef processing fill:#bfb,stroke:#333,stroke-width:2px,color:#003300
+    classDef apps fill:#fbb,stroke:#333,stroke-width:2px,color:#4a0000
     
     class Web,APIs,DB,News sources
     class SC,PA,CH,SP,CS mcp


### PR DESCRIPTION
Improves text readability in the mermaid architecture diagram by adding explicit `color` values to each `classDef`. Previously, the default text color had low contrast against the pastel fill colors (pink, purple/blue, green, orange), making labels hard to read.