### PR TITLE
[Module 08] Add safe retries and reliability sidecar lesson

### DIFF
--- a/08-BestPractices/README.md
+++ b/08-BestPractices/README.md
@@ -68,7 +68,7 @@ The following best practices are derived from the official Model Context Protoco
 
 4. **Observability**: Use `stderr` for stdio diagnostics and OpenTelemetry
    for structured observability. The MCP logging feature is deprecated in the
-   `2026-07-28` release candidate.
+   `2026-07-28` specification.
 
 5. **Progress Tracking**: For long-running operations, report progress updates to enable responsive user interfaces.
 
@@ -79,11 +79,11 @@ The following best practices are derived from the official Model Context Protoco
 For the most up-to-date information on MCP best practices, refer to:
 
 - [MCP Documentation](https://modelcontextprotocol.io/)
-- [MCP Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25)
-- [MCP 2026-07-28 Release Candidate][mcp-2026-rc]
+- [MCP Specification (2026-07-28)][mcp-2026-spec]
+- [Previous MCP Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25)
 - [MCP Tasks Extension][mcp-tasks-extension]
 - [GitHub Repository](https://github.com/modelcontextprotocol)
-- [Security Best Practices](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices)
+- [Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
 - [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/) - Security risks and mitigations
 - [MCP Security Summit Workshop (Sherpa)](https://azure-samples.github.io/sherpa/) - Hands-on security training
 
@@ -94,11 +94,11 @@ messages, deployments, or other real-world effects. A response can be lost
 after the effect commits.
 
 Use the reliability companion lesson,
-[Reliability Sidecars: Idempotency and Safe Retries][reliability-sidecar], to
-learn stable operation keys, duplicate admission, checkpointing,
+[Safe Retries for MCP Tools: A Reliability Sidecar Pattern][reliability-sidecar],
+to learn stable operation keys, duplicate admission, checkpointing,
 reconciliation, evidence levels, and failure injection.
 
-[mcp-2026-rc]: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+[mcp-2026-spec]: https://modelcontextprotocol.io/specification/2026-07-28
 [mcp-tasks-extension]: https://modelcontextprotocol.io/extensions/tasks/overview
 [reliability-sidecar]: ./reliability-sidecars/README.md
 

--- a/08-BestPractices/README.md
+++ b/08-BestPractices/README.md
@@ -30,7 +30,9 @@ Before diving into specific implementation practices, it's important to understa
 
 4. **Modular Architecture**: Design your MCP servers with a modular approach, where each tool and resource has a clear, focused purpose.
 
-5. **Stateful Connections**: Leverage MCP's ability to maintain state across multiple requests for more coherent and context-aware interactions.
+5. **Explicit State**: MCP `2026-07-28` is stateless at the protocol
+   layer. When a workflow needs cross-call state, use explicit handles or
+   ordinary tool arguments backed by durable application state.
 
 ## Official MCP Best Practices
 
@@ -44,7 +46,9 @@ The following best practices are derived from the official Model Context Protoco
 
 3. **Tool Safety**: Require explicit user consent before invoking any tool. Ensure users understand each tool's functionality and enforce robust security boundaries.
 
-4. **Tool Permission Control**: Configure which tools a model is allowed to use during a session, ensuring only explicitly authorized tools are accessible.
+4. **Tool Permission Control**: Configure which tools a model may use for
+   each request and authorization context, ensuring only explicitly authorized
+   tools are accessible.
 
 5. **Authentication**: Require proper authentication before granting access to tools, resources, or sensitive operations using API keys, OAuth tokens, or other secure authentication methods.
 
@@ -54,13 +58,17 @@ The following best practices are derived from the official Model Context Protoco
 
 ### Implementation Best Practices
 
-1. **Capability Negotiation**: During connection setup, exchange information about supported features, protocol versions, available tools, and resources.
+1. **Capability Negotiation**: Negotiate supported protocol versions and
+   capabilities. In MCP `2026-07-28`, each request is self-contained and may
+   use `server/discover`; older revisions use the initialization handshake.
 
 2. **Tool Design**: Create focused tools that do one thing well, rather than monolithic tools that handle multiple concerns.
 
 3. **Error Handling**: Implement standardized error messages and codes to help diagnose issues, handle failures gracefully, and provide actionable feedback.
 
-4. **Logging**: Configure structured logs for auditing, debugging, and monitoring protocol interactions.
+4. **Observability**: Use `stderr` for stdio diagnostics and OpenTelemetry
+   for structured observability. The MCP logging feature is deprecated in the
+   `2026-07-28` release candidate.
 
 5. **Progress Tracking**: For long-running operations, report progress updates to enable responsive user interfaces.
 
@@ -71,11 +79,28 @@ The following best practices are derived from the official Model Context Protoco
 For the most up-to-date information on MCP best practices, refer to:
 
 - [MCP Documentation](https://modelcontextprotocol.io/)
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25)
+- [MCP 2026-07-28 Release Candidate][mcp-2026-rc]
+- [MCP Tasks Extension][mcp-tasks-extension]
 - [GitHub Repository](https://github.com/modelcontextprotocol)
 - [Security Best Practices](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices)
-- [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/mcp/) - Security risks and mitigations
+- [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/) - Security risks and mitigations
 - [MCP Security Summit Workshop (Sherpa)](https://azure-samples.github.io/sherpa/) - Hands-on security training
+
+### Reliability Companion Lesson
+
+Generic retry loops are unsafe for tools that create tickets, payments,
+messages, deployments, or other real-world effects. A response can be lost
+after the effect commits.
+
+Use the reliability companion lesson,
+[Reliability Sidecars: Idempotency and Safe Retries][reliability-sidecar], to
+learn stable operation keys, duplicate admission, checkpointing,
+reconciliation, evidence levels, and failure injection.
+
+[mcp-2026-rc]: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+[mcp-tasks-extension]: https://modelcontextprotocol.io/extensions/tasks/overview
+[reliability-sidecar]: ./reliability-sidecars/README.md
 
 ## Practical Implementation Examples
 
@@ -870,7 +895,13 @@ public ToolResponse execute(ToolRequest request) {
 
 #### 3. Retry Logic
 
-Implement appropriate retry logic for transient failures:
+Use generic retry logic only for read-only calls or operations whose
+downstream contract is already idempotent. For effectful operations, a timeout
+after sending the request is ambiguous. Reconcile authoritative state and
+reuse the same stable operation key before executing again. See the
+[reliability sidecar companion lesson](./reliability-sidecars/README.md).
+
+The following bounded retry loop is suitable for a read-only lookup:
 
 ```python
 async def execute_async(self, request):
@@ -880,8 +911,8 @@ async def execute_async(self, request):
     
     while retry_count < max_retries:
         try:
-            # Call external API
-            return await self._call_api(request.parameters)
+            # Call a read-only external API
+            return await self._call_read_only_api(request.parameters)
         except TransientError as e:
             retry_count += 1
             if retry_count >= max_retries:
@@ -2345,7 +2376,8 @@ A comprehensive testing strategy is essential for developing reliable, high-qual
 
 1. **Tool Design**: Follow single responsibility principle, use dependency injection, and design for composability
 2. **Schema Design**: Create clear, well-documented schemas with proper validation constraints
-3. **Error Handling**: Implement graceful error handling, structured error responses, and retry logic
+3. **Error Handling**: Implement graceful error handling, structured error
+   responses, and outcome-aware retry logic
 4. **Performance**: Use caching, asynchronous processing, and resource throttling
 5. **Security**: Apply thorough input validation, authorization checks, and sensitive data handling
 6. **Testing**: Create comprehensive unit, integration, and end-to-end tests

--- a/08-BestPractices/reliability-sidecars/README.md
+++ b/08-BestPractices/reliability-sidecars/README.md
@@ -262,6 +262,35 @@ The sample intentionally omits stale-claim leases. A production takeover
 policy needs a bounded lease, atomic ownership transfer, and another external
 check before executing.
 
+## Optional Community Implementation
+
+Agent Enhancer Utilities is one community implementation of this
+application-level pattern. Its planner selects a recovery approach, while its
+checkpoint records claim and uncertain-result states. The domain tool or MCP
+server still performs and verifies the real action. This service is not part
+of the MCP specification and is not required for this lesson.
+
+| Lesson concept | Agent Enhancer piece | Important limit |
+| --- | --- | --- |
+| Recovery plan | `workflow-guard-planner` | Does not call the domain tool |
+| Claim and recovery | `workflow-checkpoint` | `external_proof` stays `false` |
+| Exact sidecar replay | `lab.invoke_tool` | Uses a separate idempotency key |
+| Verify the real action | Destination search/read-back | Domain MCP owns it |
+
+For an exact retry of one sidecar call, `lab.invoke_tool` accepts an outer
+`idempotency_key`. That key identifies the sidecar invocation; it is not the
+business `operation_key` used for the ticket.
+
+The tagged public contract and an optional networked example are available
+here:
+
+- [Reliability Sidecar Contract v1](https://github.com/artiehinz/Agent-Enhancer-Utilities/blob/v1.6.0/docs/RELIABILITY_SIDECAR_CONTRACT_V1.md)
+- [Planner and mock-domain example](https://github.com/artiehinz/Agent-Enhancer-Utilities/tree/v1.6.0/examples/reliability-sidecar)
+
+These links illustrate the application pattern. They do not claim that the
+hosted service conforms to MCP `2026-07-28`, and checkpoint state never counts
+as external proof of the ticket.
+
 ## Production Checklist
 
 - [ ] Create and save the operation key before the first external attempt.

--- a/08-BestPractices/reliability-sidecars/README.md
+++ b/08-BestPractices/reliability-sidecars/README.md
@@ -1,105 +1,100 @@
-# Reliability Sidecars: Idempotency and Safe Retries
+# Safe Retries for MCP Tools: A Reliability Sidecar Pattern
 
-## Overview
+A missing response does not mean the action is missing. A support-ticket tool
+may create ticket `T-0001` and then lose its connection before the client sees
+the result. If the client retries blindly, it may create `T-0002`.
 
-A tool can finish its real-world action and still appear to fail. For example,
-a server may create a support ticket, but the connection can close before the
-client receives the result. A blind retry may then create a second ticket.
+This lesson shows how to recognize that uncertain outcome, keep one stable
+identity for the intended action, and check the ticket system before trying
+again. The accompanying Python exercise runs locally with the standard library
+and SQLite.
 
-This lesson introduces a vendor-neutral **reliability sidecar** pattern for
-effectful MCP tools. Here, "sidecar" means a small reliability boundary around
-a tool operation. It can be a library, middleware component, database-backed
-service, or part of the tool implementation. It is not an MCP protocol feature
-and does not have to be a separate process.
+## Why a Timeout Means "Outcome Unknown"
 
-The pattern combines:
+Suppose the client calls `create_support_ticket` with operation key
+`op-login-ticket-0001`:
 
-- a stable operation key created before the first effectful call;
-- an immutable binding between that key, the caller, the tool, and its input;
-- durable claim and progress records;
-- reconciliation when the result is unknown; and
-- separately recorded evidence that the effect really happened.
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Tool as MCP tool
+    participant Store as Operation store
+    participant Tickets as Ticket system
 
-## Specification Status
-
-This lesson is aligned with the `2026-07-28` MCP specification release
-candidate. That revision is still a draft. The current production-ready
-protocol revision remains `2025-11-25`.
-
-The reliability pattern works with both revisions. Two details are especially
-important when targeting the release candidate:
-
-1. MCP is stateless at the protocol layer. Cross-call state must use explicit
-   handles or ordinary tool arguments rather than connection-local session
-   state.
-2. Tasks moved from an experimental core feature to a negotiated extension.
-   A task ID can help resume a long-running request, but it is not an
-   idempotency key for the external action performed by that request.
-
-## Learning Objectives
-
-By the end of this lesson, you will be able to:
-
-- explain why a timeout does not prove that a tool failed;
-- distinguish request correlation from effect deduplication;
-- design a stable operation-key contract for an effectful tool;
-- choose between retry, reconciliation, and fail-closed behavior;
-- preserve evidence independently from an agent's success message; and
-- test the "effect committed, response lost" failure mode.
-
-## The Ambiguous-Success Problem
-
-Consider a tool named `create_support_ticket`:
-
-```text
-Client          MCP server          Ticket system
-  | tools/call       |                    |
-  |----------------->|                    |
-  |                  | create ticket      |
-  |                  |------------------->|
-  |                  | ticket T-1007      |
-  |                  |<-------------------|
-  |       connection closes               |
-  |<--------------- X |                    |
+    Client->>Tool: Create (op-login-ticket-0001)
+    Tool->>Store: Claim key
+    Store-->>Tool: Claimed
+    Tool->>Tickets: Create ticket
+    Tickets-->>Tool: Committed T-0001
+    Tool--xClient: Reply lost
+    Client->>Tool: Retry same key
+    Tool->>Store: Read claim
+    Tool->>Tickets: Find by key
+    Tickets-->>Tool: Found T-0001
+    Tool->>Store: Save verified result
+    Tool-->>Client: Return T-0001
 ```
 
-The client sees a transport failure. The ticket system already contains
-`T-1007`. Retrying with no duplicate guard can create `T-1008`.
+The connection fails after the ticket commits but before the result arrives.
+The client knows only that the reply is missing. It does not know whether the
+ticket is missing. Reusing the operation key lets the tool find and return
+`T-0001` instead of creating `T-0002`.
 
-This is an **ambiguous outcome**:
+## What a Reliability Sidecar Does
 
-- retrying may repeat a real-world effect;
-- not retrying may leave the workflow unfinished; and
-- the transport error alone cannot tell the client which case occurred.
+A reliability sidecar is application code that keeps recovery state around a
+tool. It might be a library, middleware, a database-backed service, or simply
+part of the tool implementation. It does not have to be a separate process,
+and it is not an MCP protocol feature.
 
-## What MCP Mechanisms Do—and Do Not—Prove
+The sidecar has four jobs:
 
-- **JSON-RPC request ID:** matches a response to an in-flight request. It does
-  not prove that a later retry is the same business operation.
-- **Progress notification:** reports progress for an active request. It does
-  not prove that an external effect committed.
-- **Cancellation:** says a result is no longer needed or asks work to stop. It
-  does not prove that work stopped before an external effect.
-- **Trace context:** correlates telemetry across services. It does not prevent
-  duplicate effects.
-- **MCP Tasks extension:** provides a durable handle for long-running work. It
-  does not make the downstream action idempotent.
-- **Tool execution error:** gives actionable failure information. It does not
-  prove that no side effect happened before the error.
+1. save the intended action before calling the external system;
+2. let only one worker claim that action;
+3. remember enough state to recover after a crash; and
+4. check the external system when the outcome is uncertain.
 
-These mechanisms are useful, but they solve different problems. Do not use a
-JSON-RPC request ID, progress token, trace ID, or task ID as an accidental
-substitute for an explicit operation contract.
+This lesson targets the final MCP specification `2026-07-28`. MCP has no
+protocol-level session, so the operation key is an ordinary tool argument
+backed by durable application state. The same pattern also works with earlier
+MCP versions.
 
-## Step 1: Add an Explicit Operation Key
+## Four IDs That Solve Different Problems
 
-For an effectful tool, include an application-level operation key in the input
-schema:
+These identifiers are related, but they are not interchangeable:
+
+| Identifier | What it identifies | Survives a retry? |
+| --- | --- | --- |
+| JSON-RPC ID | One request and response | No; use a new request ID |
+| MCP Task ID | One long-running task | Yes; keep it for polling |
+| Operation key | One intended action | Yes; reuse it for that action |
+| Ticket ID | The stored result | Yes; return it after verification |
+
+Progress notifications and trace context help you observe a request.
+Cancellation asks work to stop. None of them prevents a duplicate ticket.
+
+## Build the Guard
+
+Create the operation key before the first tool call and save it with the
+workflow. Every attempt to create the same intended ticket uses the same key:
+
+```json
+{
+  "operation_key": "op-login-ticket-0001",
+  "title": "Cannot sign in"
+}
+```
+
+A different intended ticket gets a new key. In production, generate an opaque,
+unguessable value instead of putting customer data into the key.
+
+Here is the complete MCP tool schema used in this lesson:
 
 ```json
 {
   "name": "create_support_ticket",
-  "description": "Creates one support ticket for a stable operation key.",
+  "title": "Create support ticket",
+  "description": "Creates or recovers one support ticket for an operation key.",
   "inputSchema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -108,7 +103,7 @@ schema:
         "type": "string",
         "minLength": 16,
         "maxLength": 128,
-        "description": "Stable key reused for retries."
+        "description": "Stable key reused for the same intended action."
       },
       "title": {
         "type": "string",
@@ -131,7 +126,7 @@ schema:
       },
       "status": {
         "type": "string",
-        "enum": ["verified"]
+        "const": "verified"
       }
     },
     "required": ["ticket_id", "operation_key", "status"],
@@ -140,209 +135,147 @@ schema:
 }
 ```
 
-The client or workflow coordinator creates the key before the first attempt and
-stores it durably. Every retry of the same intended action uses the same key.
-A new intended action uses a new key.
+The authenticated caller identity comes from server context, not from
+model-supplied tool input. Scope each stored operation to:
 
-### Bind the Key to the Full Operation
+- that caller, tenant, or service account;
+- the tool name and version; and
+- a hash of the normalized inputs that define the external action.
 
-An operation key is not globally meaningful by itself. Scope it to:
+The input hash answers a simple question: "Is this retry asking for the same
+ticket?" If the key already belongs to a different title, reject the call.
+Returning an earlier result for changed input would hide a contract error.
 
-- the authenticated principal or tenant;
-- the tool name and version;
-- a canonical digest of effect-defining inputs; and
-- the authorization or policy context when relevant.
+Save the claim with one atomic database operation. "Atomic" means two workers
+cannot both observe an empty record and both become the owner. A process-local
+lock is not enough when another server instance can receive the retry.
 
-If the same scoped key arrives with different effect-defining inputs, reject
-the request. Silently accepting the new inputs could return an old result for a
-different intended action.
+The workflow creates the key while the action is `planned`. The sample then
+persists these states:
 
-Do not put secrets or personal data directly in the key. Use an opaque random
-value and store sensitive scope information on the server.
+- `claimed`: one worker has reserved the operation;
+- `completed`: the ticket system returned a result; and
+- `verified`: a read from the ticket system confirms the result.
 
-## Step 2: Record a Durable Lifecycle
+A crash can leave the stored state at `claimed` even after the ticket was
+created. Treat every nonterminal claim as uncertain until external evidence
+settles it. Do not assume that `claimed` means "nothing happened."
 
-A useful lifecycle is:
+## Recover Before You Retry
 
-```text
-planned -> claimed -> completed -> verified
-               \-> outcome_unknown
-               \-> failed
+When a tool call fails, decide what is known before sending another external
+write:
+
+```mermaid
+flowchart TD
+    A[Tool call failed] --> B{Before the external call?}
+    B -- Yes --> C[Retry the unchanged action with the same key]
+    B -- No or unsure --> D[Check the ticket system]
+    D --> E{What was found?}
+    E -- One match --> F[Verify and return it]
+    E -- Proven absent --> G{Is another attempt safe?}
+    G -- Yes --> H[Retry with the same key]
+    G -- No --> I[Stop for review]
+    E -- Unknown/conflict --> I
 ```
 
-- `planned`: the workflow has created the operation identity.
-- `claimed`: one worker owns admission for the operation.
-- `completed`: the tool or downstream service returned a result.
-- `verified`: authoritative state confirms the intended effect.
-- `outcome_unknown`: the effect may have happened, but evidence is incomplete.
-- `failed`: authoritative evidence says the effect did not complete.
+Validation that fails before the ticket API is called is a known failure.
+Retry an unchanged action with the same operation key. If correcting the input
+changes the intended ticket, create a new key for that new action.
 
-Terminal records should be immutable. If correction is necessary, append a
-new evidence record rather than rewriting history.
+If the request may have reached the ticket system, reconcile it first.
+Reconciliation means comparing the saved claim with the authoritative ticket
+record. Return the existing ticket when exactly one matching record is found.
+Retry only when the ticket is conclusively absent and the downstream contract
+makes another attempt safe.
 
-### Admission Must Be Atomic
+"Not found" is not always conclusive. A provider with eventually consistent
+search may need a bounded wait and another check. If the system cannot be
+searched, gives conflicting results, or cannot safely deduplicate another
+attempt, stop and report `outcome unknown`. Stopping here is sometimes called
+"failing closed": the workflow refuses to guess.
 
-Two workers can receive the same retry concurrently. Use a database uniqueness
-constraint, compare-and-set operation, or another atomic primitive so only one
-claim is admitted.
+## Evidence, Tasks, and Cancellation
 
-The unique identity should cover the scoped operation key. A process-local
-dictionary or lock is not sufficient when another server instance can receive
-the next request.
+A tool response says what the tool reported. A stored checkpoint says what the
+workflow recorded. The strongest evidence comes from the system that owns the
+result: for this example, a read from the ticket system that finds exactly one
+matching ticket.
 
-## Step 3: Reconcile Before Retrying
+Match the evidence to the risk. A provider message ID may be enough for a
+low-risk notification. Payments, deployments, and destructive actions may
+need provider status, ledger, or manual review evidence.
 
-When a claim exists but no terminal result is recorded:
-
-1. Query an authoritative system using the stable operation reference.
-2. If the intended effect exists exactly once, record verification and return
-   the existing result.
-3. If the effect definitely does not exist, retry with the same key only when
-   the downstream contract makes that safe.
-4. If reconciliation is unavailable or contradictory, fail closed and require
-   investigation.
-
-The strongest design forwards the operation key to a downstream API that
-supports idempotency. When that is unavailable, store the key as a searchable
-external reference or use another authoritative business identifier.
-
-If the downstream system supports neither deduplication nor reconciliation,
-the sidecar cannot manufacture exactly-once behavior. Human review may be the
-only safe response to an ambiguous outcome.
-
-## Safe Retry Decisions
-
-- **Input validation failed before admission:** this is a definite failure.
-  Correct the input; do not retry it unchanged.
-- **Rate limit or service unavailable before any effect:** this is a known-safe
-  transient failure. Retry with backoff and the same operation key.
-- **Connection closed after sending:** the outcome is ambiguous. Reconcile
-  first; never invent a new key.
-- **Existing key has a verified result:** this is a duplicate. Return the
-  recorded result.
-- **Existing claim and the effect exists:** the action previously completed.
-  Verify and return the external result.
-- **Existing claim and the effect is authoritatively absent:** the action did
-  not complete. Retry with the same key only when downstream execution is
-  safe.
-- **Same key has a different payload digest:** this is a contract conflict.
-  Reject it and investigate.
-- **Reconciliation is unavailable:** the outcome remains unknown. Fail closed
-  rather than guessing.
-
-Use bounded retries, exponential backoff, and jitter for retryable failures.
-Those controls reduce load; they do not prevent duplicate effects by
-themselves.
-
-## Step 4: Separate Responses from Evidence
-
-Treat evidence as a ladder:
-
-1. **Agent statement**: the model says the action succeeded.
-2. **Tool response**: the MCP tool returned a success result.
-3. **Durable checkpoint**: the operation store recorded a result.
-4. **External verification**: the authoritative system contains exactly the
-   intended effect.
-
-Higher levels are stronger. Promotion to `verified` should depend on the
-evidence required by the operation's risk.
-
-For a low-risk notification, a downstream message ID may be sufficient. For a
-payment, deployment, or destructive action, verification may also require
-ledger, provider, or reconciliation evidence.
-
-## MCP Tasks Complement the Pattern
-
-The `2026-07-28` Tasks extension is useful for long-running operations:
-
-- the server can return a durable task handle;
-- the client can poll `tasks/get`;
-- the client persists the task ID across restarts;
-- terminal task states do not change; and
-- cancellation is cooperative.
-
-Use a task ID to resume observation of a request. Use an operation key to
-deduplicate the business effect. A robust implementation may bind both:
+The MCP Tasks extension complements this pattern for long-running work. A Task
+ID lets the client resume polling after a disconnect, but it does not identify
+or deduplicate the ticket itself. When Tasks is used, the identities connect
+like this:
 
 ```text
-operation key -> task ID -> external effect ID -> verification evidence
+operation key -> Task ID -> ticket ID -> verification evidence
 ```
 
-The task must be durably created before its handle is returned. Even so, a
-connection can fail before the client receives that handle. The stable
-operation key still gives the server a way to recognize the retried intent.
+Cancellation is cooperative, not a rollback. The ticket may still be created
+after cancellation is acknowledged, so an uncertain result still needs
+reconciliation.
 
-Do not describe cancellation as rollback. The external action may finish even
-after cancellation is acknowledged, so reconciliation can still be necessary.
+## Run the Failure-Injection Exercise
 
-## Failure-Injection Exercise
+The sample uses two SQLite files: one represents the operation store and the
+other represents the external ticket system. There is no transaction spanning
+both files. The failure is injected after the ticket commits but before the
+sidecar records completion.
 
-The accompanying Python sample uses only the standard library and SQLite. It
-simulates a support-ticket service and deliberately raises an exception after
-the ticket commits but before the sidecar records completion.
+The direct Python method accepts `caller_id` as a stand-in for authenticated
+server context. Do not add `caller_id` to the model-controlled MCP input
+schema.
 
-Run the tests:
+Predict the result before running the tests:
+
+| Path | Result after retry | Ticket count |
+| --- | --- | --- |
+| Blind retry | Creates `T-0002` after losing the response for `T-0001` | 2 |
+| Guarded retry | Finds and returns `T-0001` | 1 |
+
+Run:
 
 ```bash
-python -m unittest discover \
-  -s 08-BestPractices/reliability-sidecars/python \
-  -p "test_*.py" \
-  -v
+cd 08-BestPractices/reliability-sidecars/python
+python -m unittest discover -p "test_*.py" -v
 ```
 
-The exercise demonstrates:
+The six tests show that:
 
-1. a naive retry creates two tickets;
-2. a guarded retry with the same key finds the first ticket;
-3. a new sidecar instance resumes from the durable claim;
-4. the verified result is reused without another effect; and
-5. reusing a key for different inputs is rejected; and
-6. a duplicate active claim with no external evidence fails closed.
-
-For clarity, the sample does not implement stale-claim leases. A production
-system that permits claim takeover needs an explicit lease-expiry policy,
-atomic ownership transfer, and another reconciliation check before execution.
+1. a blind retry creates a duplicate;
+2. response loss plus a restart recovers one ticket from a durable claim;
+3. a verified retry reuses the saved result;
+4. changed input or conflicting external evidence is rejected;
+5. an existing claim without external evidence stops safely; and
+6. concurrent claims admit one owner without regressing a verified result.
 
 Open the sample:
 
 - [Python implementation](./python/reliability_sidecar.py)
 - [Deterministic tests](./python/test_reliability_sidecar.py)
 
+The sample intentionally omits stale-claim leases. A production takeover
+policy needs a bounded lease, atomic ownership transfer, and another external
+check before executing.
+
 ## Production Checklist
 
-- [ ] Generate the operation key before the first attempt.
-- [ ] Persist the key before calling the effectful tool.
-- [ ] Scope the key to principal, tool, and canonical input digest.
-- [ ] Reject the same key with different effect-defining inputs.
-- [ ] Use atomic duplicate admission across server instances.
-- [ ] Keep records longer than the maximum retry and reconciliation window.
-- [ ] Forward the key to the downstream service when supported.
-- [ ] Reconcile ambiguous outcomes before executing again.
-- [ ] Treat progress, traces, and model statements as observations, not commit
-      evidence.
-- [ ] Treat cancellation as cooperative, not transactional rollback.
-- [ ] Record failures and conflicting evidence without overwriting history.
-- [ ] Test concurrent duplicates and the response-lost-after-commit boundary.
-- [ ] Require human review when authoritative reconciliation is impossible.
-
-## Key Takeaways
-
-1. A transport failure after an effectful call means **unknown**, not
-   necessarily **failed**.
-2. Retry safety is an application property; MCP does not promise exactly-once
-   side effects.
-3. The same intended action must keep the same scoped operation key.
-4. Reconciliation should use authoritative state, not an agent's description
-   of what happened.
-5. Tasks improve durable observation, while operation keys and reconciliation
-   prevent repeated business effects.
+- [ ] Create and save the operation key before the first external attempt.
+- [ ] Bind the key to caller, tool version, and normalized input hash.
+- [ ] Reject changed input under an existing key.
+- [ ] Admit one owner with an atomic shared-store operation.
+- [ ] Forward the key to the downstream provider when it supports idempotency.
+- [ ] Reconcile uncertain outcomes before another write.
+- [ ] Keep verified results and evidence for the full retry window.
+- [ ] Stop for review when the external outcome cannot be established safely.
 
 ## References
 
-- [MCP `2026-07-28` release candidate overview](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
-- [Curriculum: What's Changing in MCP `2026-07-28`](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md)
-- [MCP draft specification](https://modelcontextprotocol.io/specification/draft/)
-- [MCP draft tool guidance](https://modelcontextprotocol.io/specification/draft/server/tools)
+- [MCP Specification `2026-07-28`](https://modelcontextprotocol.io/specification/2026-07-28)
+- [MCP `2026-07-28` tool guidance](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
 - [MCP Tasks extension](https://modelcontextprotocol.io/extensions/tasks/overview)
-- [MCP versioning and compatibility](https://modelcontextprotocol.io/docs/2026-07-28/learn/versioning)
 - [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification)

--- a/08-BestPractices/reliability-sidecars/README.md
+++ b/08-BestPractices/reliability-sidecars/README.md
@@ -1,0 +1,348 @@
+# Reliability Sidecars: Idempotency and Safe Retries
+
+## Overview
+
+A tool can finish its real-world action and still appear to fail. For example,
+a server may create a support ticket, but the connection can close before the
+client receives the result. A blind retry may then create a second ticket.
+
+This lesson introduces a vendor-neutral **reliability sidecar** pattern for
+effectful MCP tools. Here, "sidecar" means a small reliability boundary around
+a tool operation. It can be a library, middleware component, database-backed
+service, or part of the tool implementation. It is not an MCP protocol feature
+and does not have to be a separate process.
+
+The pattern combines:
+
+- a stable operation key created before the first effectful call;
+- an immutable binding between that key, the caller, the tool, and its input;
+- durable claim and progress records;
+- reconciliation when the result is unknown; and
+- separately recorded evidence that the effect really happened.
+
+## Specification Status
+
+This lesson is aligned with the `2026-07-28` MCP specification release
+candidate. That revision is still a draft. The current production-ready
+protocol revision remains `2025-11-25`.
+
+The reliability pattern works with both revisions. Two details are especially
+important when targeting the release candidate:
+
+1. MCP is stateless at the protocol layer. Cross-call state must use explicit
+   handles or ordinary tool arguments rather than connection-local session
+   state.
+2. Tasks moved from an experimental core feature to a negotiated extension.
+   A task ID can help resume a long-running request, but it is not an
+   idempotency key for the external action performed by that request.
+
+## Learning Objectives
+
+By the end of this lesson, you will be able to:
+
+- explain why a timeout does not prove that a tool failed;
+- distinguish request correlation from effect deduplication;
+- design a stable operation-key contract for an effectful tool;
+- choose between retry, reconciliation, and fail-closed behavior;
+- preserve evidence independently from an agent's success message; and
+- test the "effect committed, response lost" failure mode.
+
+## The Ambiguous-Success Problem
+
+Consider a tool named `create_support_ticket`:
+
+```text
+Client          MCP server          Ticket system
+  | tools/call       |                    |
+  |----------------->|                    |
+  |                  | create ticket      |
+  |                  |------------------->|
+  |                  | ticket T-1007      |
+  |                  |<-------------------|
+  |       connection closes               |
+  |<--------------- X |                    |
+```
+
+The client sees a transport failure. The ticket system already contains
+`T-1007`. Retrying with no duplicate guard can create `T-1008`.
+
+This is an **ambiguous outcome**:
+
+- retrying may repeat a real-world effect;
+- not retrying may leave the workflow unfinished; and
+- the transport error alone cannot tell the client which case occurred.
+
+## What MCP Mechanisms Do—and Do Not—Prove
+
+- **JSON-RPC request ID:** matches a response to an in-flight request. It does
+  not prove that a later retry is the same business operation.
+- **Progress notification:** reports progress for an active request. It does
+  not prove that an external effect committed.
+- **Cancellation:** says a result is no longer needed or asks work to stop. It
+  does not prove that work stopped before an external effect.
+- **Trace context:** correlates telemetry across services. It does not prevent
+  duplicate effects.
+- **MCP Tasks extension:** provides a durable handle for long-running work. It
+  does not make the downstream action idempotent.
+- **Tool execution error:** gives actionable failure information. It does not
+  prove that no side effect happened before the error.
+
+These mechanisms are useful, but they solve different problems. Do not use a
+JSON-RPC request ID, progress token, trace ID, or task ID as an accidental
+substitute for an explicit operation contract.
+
+## Step 1: Add an Explicit Operation Key
+
+For an effectful tool, include an application-level operation key in the input
+schema:
+
+```json
+{
+  "name": "create_support_ticket",
+  "description": "Creates one support ticket for a stable operation key.",
+  "inputSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "operation_key": {
+        "type": "string",
+        "minLength": 16,
+        "maxLength": 128,
+        "description": "Stable key reused for retries."
+      },
+      "title": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      }
+    },
+    "required": ["operation_key", "title"],
+    "additionalProperties": false
+  },
+  "outputSchema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "ticket_id": {
+        "type": "string"
+      },
+      "operation_key": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string",
+        "enum": ["verified"]
+      }
+    },
+    "required": ["ticket_id", "operation_key", "status"],
+    "additionalProperties": false
+  }
+}
+```
+
+The client or workflow coordinator creates the key before the first attempt and
+stores it durably. Every retry of the same intended action uses the same key.
+A new intended action uses a new key.
+
+### Bind the Key to the Full Operation
+
+An operation key is not globally meaningful by itself. Scope it to:
+
+- the authenticated principal or tenant;
+- the tool name and version;
+- a canonical digest of effect-defining inputs; and
+- the authorization or policy context when relevant.
+
+If the same scoped key arrives with different effect-defining inputs, reject
+the request. Silently accepting the new inputs could return an old result for a
+different intended action.
+
+Do not put secrets or personal data directly in the key. Use an opaque random
+value and store sensitive scope information on the server.
+
+## Step 2: Record a Durable Lifecycle
+
+A useful lifecycle is:
+
+```text
+planned -> claimed -> completed -> verified
+               \-> outcome_unknown
+               \-> failed
+```
+
+- `planned`: the workflow has created the operation identity.
+- `claimed`: one worker owns admission for the operation.
+- `completed`: the tool or downstream service returned a result.
+- `verified`: authoritative state confirms the intended effect.
+- `outcome_unknown`: the effect may have happened, but evidence is incomplete.
+- `failed`: authoritative evidence says the effect did not complete.
+
+Terminal records should be immutable. If correction is necessary, append a
+new evidence record rather than rewriting history.
+
+### Admission Must Be Atomic
+
+Two workers can receive the same retry concurrently. Use a database uniqueness
+constraint, compare-and-set operation, or another atomic primitive so only one
+claim is admitted.
+
+The unique identity should cover the scoped operation key. A process-local
+dictionary or lock is not sufficient when another server instance can receive
+the next request.
+
+## Step 3: Reconcile Before Retrying
+
+When a claim exists but no terminal result is recorded:
+
+1. Query an authoritative system using the stable operation reference.
+2. If the intended effect exists exactly once, record verification and return
+   the existing result.
+3. If the effect definitely does not exist, retry with the same key only when
+   the downstream contract makes that safe.
+4. If reconciliation is unavailable or contradictory, fail closed and require
+   investigation.
+
+The strongest design forwards the operation key to a downstream API that
+supports idempotency. When that is unavailable, store the key as a searchable
+external reference or use another authoritative business identifier.
+
+If the downstream system supports neither deduplication nor reconciliation,
+the sidecar cannot manufacture exactly-once behavior. Human review may be the
+only safe response to an ambiguous outcome.
+
+## Safe Retry Decisions
+
+- **Input validation failed before admission:** this is a definite failure.
+  Correct the input; do not retry it unchanged.
+- **Rate limit or service unavailable before any effect:** this is a known-safe
+  transient failure. Retry with backoff and the same operation key.
+- **Connection closed after sending:** the outcome is ambiguous. Reconcile
+  first; never invent a new key.
+- **Existing key has a verified result:** this is a duplicate. Return the
+  recorded result.
+- **Existing claim and the effect exists:** the action previously completed.
+  Verify and return the external result.
+- **Existing claim and the effect is authoritatively absent:** the action did
+  not complete. Retry with the same key only when downstream execution is
+  safe.
+- **Same key has a different payload digest:** this is a contract conflict.
+  Reject it and investigate.
+- **Reconciliation is unavailable:** the outcome remains unknown. Fail closed
+  rather than guessing.
+
+Use bounded retries, exponential backoff, and jitter for retryable failures.
+Those controls reduce load; they do not prevent duplicate effects by
+themselves.
+
+## Step 4: Separate Responses from Evidence
+
+Treat evidence as a ladder:
+
+1. **Agent statement**: the model says the action succeeded.
+2. **Tool response**: the MCP tool returned a success result.
+3. **Durable checkpoint**: the operation store recorded a result.
+4. **External verification**: the authoritative system contains exactly the
+   intended effect.
+
+Higher levels are stronger. Promotion to `verified` should depend on the
+evidence required by the operation's risk.
+
+For a low-risk notification, a downstream message ID may be sufficient. For a
+payment, deployment, or destructive action, verification may also require
+ledger, provider, or reconciliation evidence.
+
+## MCP Tasks Complement the Pattern
+
+The `2026-07-28` Tasks extension is useful for long-running operations:
+
+- the server can return a durable task handle;
+- the client can poll `tasks/get`;
+- the client persists the task ID across restarts;
+- terminal task states do not change; and
+- cancellation is cooperative.
+
+Use a task ID to resume observation of a request. Use an operation key to
+deduplicate the business effect. A robust implementation may bind both:
+
+```text
+operation key -> task ID -> external effect ID -> verification evidence
+```
+
+The task must be durably created before its handle is returned. Even so, a
+connection can fail before the client receives that handle. The stable
+operation key still gives the server a way to recognize the retried intent.
+
+Do not describe cancellation as rollback. The external action may finish even
+after cancellation is acknowledged, so reconciliation can still be necessary.
+
+## Failure-Injection Exercise
+
+The accompanying Python sample uses only the standard library and SQLite. It
+simulates a support-ticket service and deliberately raises an exception after
+the ticket commits but before the sidecar records completion.
+
+Run the tests:
+
+```bash
+python -m unittest discover \
+  -s 08-BestPractices/reliability-sidecars/python \
+  -p "test_*.py" \
+  -v
+```
+
+The exercise demonstrates:
+
+1. a naive retry creates two tickets;
+2. a guarded retry with the same key finds the first ticket;
+3. a new sidecar instance resumes from the durable claim;
+4. the verified result is reused without another effect; and
+5. reusing a key for different inputs is rejected; and
+6. a duplicate active claim with no external evidence fails closed.
+
+For clarity, the sample does not implement stale-claim leases. A production
+system that permits claim takeover needs an explicit lease-expiry policy,
+atomic ownership transfer, and another reconciliation check before execution.
+
+Open the sample:
+
+- [Python implementation](./python/reliability_sidecar.py)
+- [Deterministic tests](./python/test_reliability_sidecar.py)
+
+## Production Checklist
+
+- [ ] Generate the operation key before the first attempt.
+- [ ] Persist the key before calling the effectful tool.
+- [ ] Scope the key to principal, tool, and canonical input digest.
+- [ ] Reject the same key with different effect-defining inputs.
+- [ ] Use atomic duplicate admission across server instances.
+- [ ] Keep records longer than the maximum retry and reconciliation window.
+- [ ] Forward the key to the downstream service when supported.
+- [ ] Reconcile ambiguous outcomes before executing again.
+- [ ] Treat progress, traces, and model statements as observations, not commit
+      evidence.
+- [ ] Treat cancellation as cooperative, not transactional rollback.
+- [ ] Record failures and conflicting evidence without overwriting history.
+- [ ] Test concurrent duplicates and the response-lost-after-commit boundary.
+- [ ] Require human review when authoritative reconciliation is impossible.
+
+## Key Takeaways
+
+1. A transport failure after an effectful call means **unknown**, not
+   necessarily **failed**.
+2. Retry safety is an application property; MCP does not promise exactly-once
+   side effects.
+3. The same intended action must keep the same scoped operation key.
+4. Reconciliation should use authoritative state, not an agent's description
+   of what happened.
+5. Tasks improve durable observation, while operation keys and reconciliation
+   prevent repeated business effects.
+
+## References
+
+- [MCP `2026-07-28` release candidate overview](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [Curriculum: What's Changing in MCP `2026-07-28`](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md)
+- [MCP draft specification](https://modelcontextprotocol.io/specification/draft/)
+- [MCP draft tool guidance](https://modelcontextprotocol.io/specification/draft/server/tools)
+- [MCP Tasks extension](https://modelcontextprotocol.io/extensions/tasks/overview)
+- [MCP versioning and compatibility](https://modelcontextprotocol.io/docs/2026-07-28/learn/versioning)
+- [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification)

--- a/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
@@ -190,6 +190,10 @@ class ReliabilitySidecar:
             )
             return result
         if not claim_created:
+            if record["state"] == "completed":
+                raise ReconciliationConflict(
+                    "completed operation has no matching external ticket"
+                )
             raise OperationInProgress(
                 "an existing claim has no terminal external evidence"
             )

--- a/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
@@ -1,0 +1,405 @@
+"""Deterministic reliability-sidecar example using only Python and SQLite."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+class ResponseLost(RuntimeError):
+    """Simulates a transport failure after an external effect committed."""
+
+
+class OperationKeyConflict(ValueError):
+    """The same scoped key was reused for different effect-defining input."""
+
+
+class OperationInProgress(RuntimeError):
+    """Another worker owns the claim and no terminal evidence exists yet."""
+
+
+class ReconciliationConflict(RuntimeError):
+    """Authoritative state contains contradictory duplicate effects."""
+
+
+@dataclass(frozen=True)
+class Ticket:
+    ticket_id: str
+    title: str
+    principal: Optional[str]
+    operation_key: Optional[str]
+
+
+class TicketService:
+    """Small stand-in for an external service with searchable references."""
+
+    def __init__(self, database_path: Path) -> None:
+        self.database_path = database_path
+        with closing(self._connect()) as connection, connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tickets (
+                    ticket_number INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    principal TEXT,
+                    operation_key TEXT
+                )
+                """
+            )
+
+    def create_ticket(
+        self,
+        *,
+        title: str,
+        principal: Optional[str],
+        operation_key: Optional[str],
+    ) -> Ticket:
+        """Commit a ticket. This service does not deduplicate requests."""
+
+        with closing(self._connect()) as connection, connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO tickets (title, principal, operation_key)
+                VALUES (?, ?, ?)
+                """,
+                (title, principal, operation_key),
+            )
+            ticket_number = int(cursor.lastrowid)
+        return Ticket(
+            ticket_id=f"T-{ticket_number:04d}",
+            title=title,
+            principal=principal,
+            operation_key=operation_key,
+        )
+
+    def find_by_operation_key(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+    ) -> Optional[Ticket]:
+        """Reconcile one operation reference against authoritative state."""
+
+        with closing(self._connect()) as connection, connection:
+            rows = connection.execute(
+                """
+                SELECT ticket_number, title, principal, operation_key
+                FROM tickets
+                WHERE principal = ?
+                  AND operation_key = ?
+                ORDER BY ticket_number
+                LIMIT 2
+                """,
+                (principal, operation_key),
+            ).fetchall()
+        if len(rows) > 1:
+            raise ReconciliationConflict(
+                "more than one ticket exists for the operation key"
+            )
+        if not rows:
+            return None
+        row = rows[0]
+        return Ticket(
+            ticket_id=f"T-{int(row['ticket_number']):04d}",
+            title=str(row["title"]),
+            principal=str(row["principal"]),
+            operation_key=str(row["operation_key"]),
+        )
+
+    def ticket_count(self) -> int:
+        with closing(self._connect()) as connection, connection:
+            row = connection.execute("SELECT COUNT(*) AS count FROM tickets").fetchone()
+        return int(row["count"])
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+
+class ReliabilitySidecar:
+    """Guards one effectful tool with durable claims and reconciliation."""
+
+    TOOL_NAME = "create_support_ticket"
+
+    def __init__(
+        self,
+        database_path: Path,
+        ticket_service: TicketService,
+    ) -> None:
+        self.database_path = database_path
+        self.ticket_service = ticket_service
+        with closing(self._connect()) as connection, connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS operations (
+                    principal TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    operation_key TEXT NOT NULL,
+                    payload_digest TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    result_json TEXT,
+                    PRIMARY KEY (principal, tool_name, operation_key)
+                )
+                """
+            )
+
+    def create_support_ticket(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+        title: str,
+        inject_response_loss: bool = False,
+    ) -> Dict[str, str]:
+        """Create or recover exactly one intended support-ticket operation."""
+
+        payload_digest = self._payload_digest({"title": title})
+        record, claim_created = self._claim(
+            principal=principal,
+            operation_key=operation_key,
+            payload_digest=payload_digest,
+        )
+
+        if record["payload_digest"] != payload_digest:
+            raise OperationKeyConflict(
+                "operation key is already bound to different input"
+            )
+
+        if record["state"] == "verified":
+            return self._decode_result(record)
+
+        # A claimed record may represent a crashed worker. A completed record
+        # may represent a crash between checkpointing and verification.
+        existing_ticket = self.ticket_service.find_by_operation_key(
+            principal=principal,
+            operation_key=operation_key,
+        )
+        if existing_ticket is not None:
+            result = self._result(existing_ticket)
+            self._mark_verified(
+                principal=principal,
+                operation_key=operation_key,
+                result=result,
+            )
+            return result
+        if not claim_created:
+            raise OperationInProgress(
+                "an existing claim has no terminal external evidence"
+            )
+
+        ticket = self.ticket_service.create_ticket(
+            title=title,
+            principal=principal,
+            operation_key=operation_key,
+        )
+
+        # The effect is durable, but the caller never sees the response and the
+        # operation record is still "claimed".
+        if inject_response_loss:
+            raise ResponseLost("ticket committed, but the response was lost")
+
+        result = self._result(ticket)
+        self._mark_completed(
+            principal=principal,
+            operation_key=operation_key,
+            result=result,
+        )
+
+        verified_ticket = self.ticket_service.find_by_operation_key(
+            principal=principal,
+            operation_key=operation_key,
+        )
+        if verified_ticket is None:
+            raise ReconciliationConflict(
+                "ticket response was returned but authoritative state is empty"
+            )
+        verified_result = self._result(verified_ticket)
+        self._mark_verified(
+            principal=principal,
+            operation_key=operation_key,
+            result=verified_result,
+        )
+        return verified_result
+
+    def operation_state(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+    ) -> Optional[str]:
+        with closing(self._connect()) as connection, connection:
+            row = connection.execute(
+                """
+                SELECT state
+                FROM operations
+                WHERE principal = ?
+                  AND tool_name = ?
+                  AND operation_key = ?
+                """,
+                (principal, self.TOOL_NAME, operation_key),
+            ).fetchone()
+        return None if row is None else str(row["state"])
+
+    def _claim(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+        payload_digest: str,
+    ) -> Tuple[sqlite3.Row, bool]:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO operations (
+                    principal,
+                    tool_name,
+                    operation_key,
+                    payload_digest,
+                    state,
+                    result_json
+                )
+                VALUES (?, ?, ?, ?, 'claimed', NULL)
+                """,
+                (
+                    principal,
+                    self.TOOL_NAME,
+                    operation_key,
+                    payload_digest,
+                ),
+            )
+            claim_created = cursor.rowcount == 1
+            row = connection.execute(
+                """
+                SELECT payload_digest, state, result_json
+                FROM operations
+                WHERE principal = ?
+                  AND tool_name = ?
+                  AND operation_key = ?
+                """,
+                (principal, self.TOOL_NAME, operation_key),
+            ).fetchone()
+            connection.commit()
+        finally:
+            connection.close()
+        if row is None:
+            raise RuntimeError("operation claim disappeared")
+        return row, claim_created
+
+    def _mark_completed(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+        result: Dict[str, str],
+    ) -> None:
+        self._update_state(
+            principal=principal,
+            operation_key=operation_key,
+            state="completed",
+            result=result,
+        )
+
+    def _mark_verified(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+        result: Dict[str, str],
+    ) -> None:
+        self._update_state(
+            principal=principal,
+            operation_key=operation_key,
+            state="verified",
+            result=result,
+        )
+
+    def _update_state(
+        self,
+        *,
+        principal: str,
+        operation_key: str,
+        state: str,
+        result: Dict[str, str],
+    ) -> None:
+        encoded = json.dumps(result, sort_keys=True, separators=(",", ":"))
+        with closing(self._connect()) as connection, connection:
+            cursor = connection.execute(
+                """
+                UPDATE operations
+                SET state = ?, result_json = ?
+                WHERE principal = ?
+                  AND tool_name = ?
+                  AND operation_key = ?
+                """,
+                (
+                    state,
+                    encoded,
+                    principal,
+                    self.TOOL_NAME,
+                    operation_key,
+                ),
+            )
+        if cursor.rowcount != 1:
+            raise RuntimeError("operation state update failed")
+
+    @staticmethod
+    def _payload_digest(payload: Dict[str, str]) -> str:
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _result(ticket: Ticket) -> Dict[str, str]:
+        if ticket.operation_key is None:
+            raise ReconciliationConflict(
+                "guarded ticket is missing its operation reference"
+            )
+        return {
+            "ticket_id": ticket.ticket_id,
+            "operation_key": ticket.operation_key,
+            "status": "verified",
+        }
+
+    @staticmethod
+    def _decode_result(record: sqlite3.Row) -> Dict[str, str]:
+        raw = record["result_json"]
+        if not isinstance(raw, str):
+            raise RuntimeError("verified operation is missing its result")
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise RuntimeError("verified operation result is invalid")
+        return {str(key): str(item) for key, item in value.items()}
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+
+def naive_create_support_ticket(
+    ticket_service: TicketService,
+    *,
+    title: str,
+    inject_response_loss: bool = False,
+) -> Ticket:
+    """Demonstrate a retryable-looking call with no duplicate guard."""
+
+    ticket = ticket_service.create_ticket(
+        title=title,
+        principal=None,
+        operation_key=None,
+    )
+    if inject_response_loss:
+        raise ResponseLost("ticket committed, but the response was lost")
+    return ticket

--- a/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/reliability_sidecar.py
@@ -31,22 +31,22 @@ class ReconciliationConflict(RuntimeError):
 class Ticket:
     ticket_id: str
     title: str
-    principal: Optional[str]
+    caller_id: Optional[str]
     operation_key: Optional[str]
 
 
 class TicketService:
     """Small stand-in for an external service with searchable references."""
 
-    def __init__(self, database_path: Path) -> None:
-        self.database_path = database_path
+    def __init__(self, ticket_database_path: Path) -> None:
+        self.ticket_database_path = ticket_database_path
         with closing(self._connect()) as connection, connection:
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS tickets (
                     ticket_number INTEGER PRIMARY KEY AUTOINCREMENT,
                     title TEXT NOT NULL,
-                    principal TEXT,
+                    caller_id TEXT,
                     operation_key TEXT
                 )
                 """
@@ -56,7 +56,7 @@ class TicketService:
         self,
         *,
         title: str,
-        principal: Optional[str],
+        caller_id: Optional[str],
         operation_key: Optional[str],
     ) -> Ticket:
         """Commit a ticket. This service does not deduplicate requests."""
@@ -64,23 +64,23 @@ class TicketService:
         with closing(self._connect()) as connection, connection:
             cursor = connection.execute(
                 """
-                INSERT INTO tickets (title, principal, operation_key)
+                INSERT INTO tickets (title, caller_id, operation_key)
                 VALUES (?, ?, ?)
                 """,
-                (title, principal, operation_key),
+                (title, caller_id, operation_key),
             )
             ticket_number = int(cursor.lastrowid)
         return Ticket(
             ticket_id=f"T-{ticket_number:04d}",
             title=title,
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
         )
 
     def find_by_operation_key(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
     ) -> Optional[Ticket]:
         """Reconcile one operation reference against authoritative state."""
@@ -88,14 +88,14 @@ class TicketService:
         with closing(self._connect()) as connection, connection:
             rows = connection.execute(
                 """
-                SELECT ticket_number, title, principal, operation_key
+                SELECT ticket_number, title, caller_id, operation_key
                 FROM tickets
-                WHERE principal = ?
+                WHERE caller_id = ?
                   AND operation_key = ?
                 ORDER BY ticket_number
                 LIMIT 2
                 """,
-                (principal, operation_key),
+                (caller_id, operation_key),
             ).fetchall()
         if len(rows) > 1:
             raise ReconciliationConflict(
@@ -107,7 +107,7 @@ class TicketService:
         return Ticket(
             ticket_id=f"T-{int(row['ticket_number']):04d}",
             title=str(row["title"]),
-            principal=str(row["principal"]),
+            caller_id=str(row["caller_id"]),
             operation_key=str(row["operation_key"]),
         )
 
@@ -117,34 +117,34 @@ class TicketService:
         return int(row["count"])
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self.database_path)
+        connection = sqlite3.connect(self.ticket_database_path)
         connection.row_factory = sqlite3.Row
         return connection
 
 
 class ReliabilitySidecar:
-    """Guards one effectful tool with durable claims and reconciliation."""
+    """Guards a ticket-creating tool with durable claims and reconciliation."""
 
-    TOOL_NAME = "create_support_ticket"
+    TOOL_ID = "create_support_ticket:v1"
 
     def __init__(
         self,
-        database_path: Path,
+        operation_database_path: Path,
         ticket_service: TicketService,
     ) -> None:
-        self.database_path = database_path
+        self.operation_database_path = operation_database_path
         self.ticket_service = ticket_service
         with closing(self._connect()) as connection, connection:
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS operations (
-                    principal TEXT NOT NULL,
-                    tool_name TEXT NOT NULL,
+                    caller_id TEXT NOT NULL,
+                    tool_id TEXT NOT NULL,
                     operation_key TEXT NOT NULL,
-                    payload_digest TEXT NOT NULL,
+                    input_hash TEXT NOT NULL,
                     state TEXT NOT NULL,
                     result_json TEXT,
-                    PRIMARY KEY (principal, tool_name, operation_key)
+                    PRIMARY KEY (caller_id, tool_id, operation_key)
                 )
                 """
             )
@@ -152,21 +152,21 @@ class ReliabilitySidecar:
     def create_support_ticket(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
         title: str,
         inject_response_loss: bool = False,
     ) -> Dict[str, str]:
-        """Create or recover exactly one intended support-ticket operation."""
+        """Create or recover one intended support-ticket operation."""
 
-        payload_digest = self._payload_digest({"title": title})
+        input_hash = self._input_hash({"title": title})
         record, claim_created = self._claim(
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
-            payload_digest=payload_digest,
+            input_hash=input_hash,
         )
 
-        if record["payload_digest"] != payload_digest:
+        if record["input_hash"] != input_hash:
             raise OperationKeyConflict(
                 "operation key is already bound to different input"
             )
@@ -177,13 +177,14 @@ class ReliabilitySidecar:
         # A claimed record may represent a crashed worker. A completed record
         # may represent a crash between checkpointing and verification.
         existing_ticket = self.ticket_service.find_by_operation_key(
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
         )
         if existing_ticket is not None:
-            result = self._result(existing_ticket)
+            self._require_matching_ticket(existing_ticket, expected_title=title)
+            result = self._result(existing_ticket, status="verified")
             self._mark_verified(
-                principal=principal,
+                caller_id=caller_id,
                 operation_key=operation_key,
                 result=result,
             )
@@ -195,7 +196,7 @@ class ReliabilitySidecar:
 
         ticket = self.ticket_service.create_ticket(
             title=title,
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
         )
 
@@ -204,24 +205,25 @@ class ReliabilitySidecar:
         if inject_response_loss:
             raise ResponseLost("ticket committed, but the response was lost")
 
-        result = self._result(ticket)
+        result = self._result(ticket, status="completed")
         self._mark_completed(
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
             result=result,
         )
 
         verified_ticket = self.ticket_service.find_by_operation_key(
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
         )
         if verified_ticket is None:
             raise ReconciliationConflict(
                 "ticket response was returned but authoritative state is empty"
             )
-        verified_result = self._result(verified_ticket)
+        self._require_matching_ticket(verified_ticket, expected_title=title)
+        verified_result = self._result(verified_ticket, status="verified")
         self._mark_verified(
-            principal=principal,
+            caller_id=caller_id,
             operation_key=operation_key,
             result=verified_result,
         )
@@ -230,28 +232,40 @@ class ReliabilitySidecar:
     def operation_state(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
     ) -> Optional[str]:
+        record = self._operation_record(
+            caller_id=caller_id,
+            operation_key=operation_key,
+        )
+        return None if record is None else str(record["state"])
+
+    def _operation_record(
+        self,
+        *,
+        caller_id: str,
+        operation_key: str,
+    ) -> Optional[sqlite3.Row]:
         with closing(self._connect()) as connection, connection:
             row = connection.execute(
                 """
-                SELECT state
+                SELECT input_hash, state, result_json
                 FROM operations
-                WHERE principal = ?
-                  AND tool_name = ?
+                WHERE caller_id = ?
+                  AND tool_id = ?
                   AND operation_key = ?
                 """,
-                (principal, self.TOOL_NAME, operation_key),
+                (caller_id, self.TOOL_ID, operation_key),
             ).fetchone()
-        return None if row is None else str(row["state"])
+        return row
 
     def _claim(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
-        payload_digest: str,
+        input_hash: str,
     ) -> Tuple[sqlite3.Row, bool]:
         connection = self._connect()
         try:
@@ -259,32 +273,32 @@ class ReliabilitySidecar:
             cursor = connection.execute(
                 """
                 INSERT OR IGNORE INTO operations (
-                    principal,
-                    tool_name,
+                    caller_id,
+                    tool_id,
                     operation_key,
-                    payload_digest,
+                    input_hash,
                     state,
                     result_json
                 )
                 VALUES (?, ?, ?, ?, 'claimed', NULL)
                 """,
                 (
-                    principal,
-                    self.TOOL_NAME,
+                    caller_id,
+                    self.TOOL_ID,
                     operation_key,
-                    payload_digest,
+                    input_hash,
                 ),
             )
             claim_created = cursor.rowcount == 1
             row = connection.execute(
                 """
-                SELECT payload_digest, state, result_json
+                SELECT input_hash, state, result_json
                 FROM operations
-                WHERE principal = ?
-                  AND tool_name = ?
+                WHERE caller_id = ?
+                  AND tool_id = ?
                   AND operation_key = ?
                 """,
-                (principal, self.TOOL_NAME, operation_key),
+                (caller_id, self.TOOL_ID, operation_key),
             ).fetchone()
             connection.commit()
         finally:
@@ -296,62 +310,86 @@ class ReliabilitySidecar:
     def _mark_completed(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
         result: Dict[str, str],
     ) -> None:
-        self._update_state(
-            principal=principal,
+        updated = self._update_state(
+            caller_id=caller_id,
             operation_key=operation_key,
             state="completed",
             result=result,
+            allowed_states=("claimed", "completed"),
         )
+        if updated:
+            return
+        record = self._operation_record(
+            caller_id=caller_id,
+            operation_key=operation_key,
+        )
+        if record is None or record["state"] != "verified":
+            raise RuntimeError("operation completion update failed")
 
     def _mark_verified(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
         result: Dict[str, str],
     ) -> None:
-        self._update_state(
-            principal=principal,
+        updated = self._update_state(
+            caller_id=caller_id,
             operation_key=operation_key,
             state="verified",
             result=result,
+            allowed_states=("claimed", "completed"),
         )
+        if updated:
+            return
+        record = self._operation_record(
+            caller_id=caller_id,
+            operation_key=operation_key,
+        )
+        if record is None or record["state"] != "verified":
+            raise RuntimeError("operation verification update failed")
+        if self._decode_result(record) != result:
+            raise ReconciliationConflict(
+                "verified operation result conflicts with external evidence"
+            )
 
     def _update_state(
         self,
         *,
-        principal: str,
+        caller_id: str,
         operation_key: str,
         state: str,
         result: Dict[str, str],
-    ) -> None:
+        allowed_states: Tuple[str, str],
+    ) -> bool:
         encoded = json.dumps(result, sort_keys=True, separators=(",", ":"))
         with closing(self._connect()) as connection, connection:
             cursor = connection.execute(
                 """
                 UPDATE operations
                 SET state = ?, result_json = ?
-                WHERE principal = ?
-                  AND tool_name = ?
+                WHERE caller_id = ?
+                  AND tool_id = ?
                   AND operation_key = ?
+                  AND state IN (?, ?)
                 """,
                 (
                     state,
                     encoded,
-                    principal,
-                    self.TOOL_NAME,
+                    caller_id,
+                    self.TOOL_ID,
                     operation_key,
+                    *allowed_states,
                 ),
             )
-        if cursor.rowcount != 1:
-            raise RuntimeError("operation state update failed")
+        return cursor.rowcount == 1
 
     @staticmethod
-    def _payload_digest(payload: Dict[str, str]) -> str:
+    def _input_hash(payload: Dict[str, str]) -> str:
         encoded = json.dumps(
             payload,
             sort_keys=True,
@@ -360,15 +398,28 @@ class ReliabilitySidecar:
         return hashlib.sha256(encoded).hexdigest()
 
     @staticmethod
-    def _result(ticket: Ticket) -> Dict[str, str]:
+    def _require_matching_ticket(
+        ticket: Ticket,
+        *,
+        expected_title: str,
+    ) -> None:
+        if ticket.title != expected_title:
+            raise ReconciliationConflict(
+                "ticket found for the operation key has different input"
+            )
+
+    @staticmethod
+    def _result(ticket: Ticket, *, status: str) -> Dict[str, str]:
         if ticket.operation_key is None:
             raise ReconciliationConflict(
                 "guarded ticket is missing its operation reference"
             )
+        if status not in {"completed", "verified"}:
+            raise ValueError(f"unsupported operation status: {status}")
         return {
             "ticket_id": ticket.ticket_id,
             "operation_key": ticket.operation_key,
-            "status": "verified",
+            "status": status,
         }
 
     @staticmethod
@@ -382,7 +433,7 @@ class ReliabilitySidecar:
         return {str(key): str(item) for key, item in value.items()}
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self.database_path)
+        connection = sqlite3.connect(self.operation_database_path)
         connection.row_factory = sqlite3.Row
         return connection
 
@@ -397,7 +448,7 @@ def naive_create_support_ticket(
 
     ticket = ticket_service.create_ticket(
         title=title,
-        principal=None,
+        caller_id=None,
         operation_key=None,
     )
     if inject_response_loss:

--- a/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from reliability_sidecar import (
+    OperationInProgress,
+    OperationKeyConflict,
+    ReliabilitySidecar,
+    ResponseLost,
+    TicketService,
+    naive_create_support_ticket,
+)
+
+
+class ReliabilitySidecarTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.database_path = Path(self.temporary_directory.name) / "exercise.sqlite3"
+        self.ticket_service = TicketService(self.database_path)
+        self.sidecar = ReliabilitySidecar(
+            self.database_path,
+            self.ticket_service,
+        )
+
+    def test_naive_retry_repeats_a_committed_effect(self) -> None:
+        with self.assertRaises(ResponseLost):
+            naive_create_support_ticket(
+                self.ticket_service,
+                title="Cannot sign in",
+                inject_response_loss=True,
+            )
+
+        second_ticket = naive_create_support_ticket(
+            self.ticket_service,
+            title="Cannot sign in",
+        )
+
+        self.assertEqual("T-0002", second_ticket.ticket_id)
+        self.assertEqual(2, self.ticket_service.ticket_count())
+
+    def test_guarded_retry_reconciles_after_response_loss(self) -> None:
+        operation_key = "op-login-ticket-0001"
+        with self.assertRaises(ResponseLost):
+            self.sidecar.create_support_ticket(
+                principal="customer-42",
+                operation_key=operation_key,
+                title="Cannot sign in",
+                inject_response_loss=True,
+            )
+
+        # A new object represents a restarted worker with no process-local
+        # memory of the first attempt.
+        restarted_sidecar = ReliabilitySidecar(
+            self.database_path,
+            self.ticket_service,
+        )
+        result = restarted_sidecar.create_support_ticket(
+            principal="customer-42",
+            operation_key=operation_key,
+            title="Cannot sign in",
+        )
+
+        self.assertEqual("T-0001", result["ticket_id"])
+        self.assertEqual("verified", result["status"])
+        self.assertEqual(1, self.ticket_service.ticket_count())
+        self.assertEqual(
+            "verified",
+            restarted_sidecar.operation_state(
+                principal="customer-42",
+                operation_key=operation_key,
+            ),
+        )
+
+    def test_verified_retry_returns_cached_result(self) -> None:
+        arguments = {
+            "principal": "customer-42",
+            "operation_key": "op-billing-ticket-0001",
+            "title": "Invoice is missing",
+        }
+
+        first = self.sidecar.create_support_ticket(**arguments)
+        second = self.sidecar.create_support_ticket(**arguments)
+
+        self.assertEqual(first, second)
+        self.assertEqual(1, self.ticket_service.ticket_count())
+
+    def test_same_key_with_different_input_is_rejected(self) -> None:
+        operation_key = "op-profile-ticket-0001"
+        self.sidecar.create_support_ticket(
+            principal="customer-42",
+            operation_key=operation_key,
+            title="Profile is unavailable",
+        )
+
+        with self.assertRaises(OperationKeyConflict):
+            self.sidecar.create_support_ticket(
+                principal="customer-42",
+                operation_key=operation_key,
+                title="Delete my profile",
+            )
+
+        self.assertEqual(1, self.ticket_service.ticket_count())
+
+    def test_existing_claim_without_evidence_does_not_repeat_effect(self) -> None:
+        operation_key = "op-active-claim-0001"
+        payload_digest = self.sidecar._payload_digest({"title": "Still processing"})
+        _, claim_created = self.sidecar._claim(
+            principal="customer-42",
+            operation_key=operation_key,
+            payload_digest=payload_digest,
+        )
+        self.assertTrue(claim_created)
+
+        with self.assertRaises(OperationInProgress):
+            self.sidecar.create_support_ticket(
+                principal="customer-42",
+                operation_key=operation_key,
+                title="Still processing",
+            )
+
+        self.assertEqual(0, self.ticket_service.ticket_count())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
@@ -154,6 +154,22 @@ class ReliabilitySidecarTests(unittest.TestCase):
                 title="Cannot sign in",
             )
 
+        self.sidecar._mark_completed(
+            caller_id="customer-42",
+            operation_key=operation_key,
+            result={
+                "ticket_id": "T-0001",
+                "operation_key": operation_key,
+                "status": "completed",
+            },
+        )
+        with self.assertRaises(ReconciliationConflict):
+            self.sidecar.create_support_ticket(
+                caller_id="customer-42",
+                operation_key=operation_key,
+                title="Cannot sign in",
+            )
+
         self.assertEqual(0, self.ticket_service.ticket_count())
 
     def test_concurrent_claims_admit_one_owner_without_state_regression(

--- a/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
+++ b/08-BestPractices/reliability-sidecars/python/test_reliability_sidecar.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import tempfile
+from threading import Barrier
 import unittest
 from pathlib import Path
 
 from reliability_sidecar import (
     OperationInProgress,
     OperationKeyConflict,
+    ReconciliationConflict,
     ReliabilitySidecar,
     ResponseLost,
     TicketService,
@@ -18,10 +21,12 @@ class ReliabilitySidecarTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary_directory.cleanup)
-        self.database_path = Path(self.temporary_directory.name) / "exercise.sqlite3"
-        self.ticket_service = TicketService(self.database_path)
+        self.temporary_path = Path(self.temporary_directory.name)
+        self.ticket_database_path = self.temporary_path / "tickets.sqlite3"
+        self.operation_database_path = self.temporary_path / "operations.sqlite3"
+        self.ticket_service = TicketService(self.ticket_database_path)
         self.sidecar = ReliabilitySidecar(
-            self.database_path,
+            self.operation_database_path,
             self.ticket_service,
         )
 
@@ -45,20 +50,28 @@ class ReliabilitySidecarTests(unittest.TestCase):
         operation_key = "op-login-ticket-0001"
         with self.assertRaises(ResponseLost):
             self.sidecar.create_support_ticket(
-                principal="customer-42",
+                caller_id="customer-42",
                 operation_key=operation_key,
                 title="Cannot sign in",
                 inject_response_loss=True,
             )
 
+        self.assertEqual(
+            "claimed",
+            self.sidecar.operation_state(
+                caller_id="customer-42",
+                operation_key=operation_key,
+            ),
+        )
+
         # A new object represents a restarted worker with no process-local
         # memory of the first attempt.
         restarted_sidecar = ReliabilitySidecar(
-            self.database_path,
+            self.operation_database_path,
             self.ticket_service,
         )
         result = restarted_sidecar.create_support_ticket(
-            principal="customer-42",
+            caller_id="customer-42",
             operation_key=operation_key,
             title="Cannot sign in",
         )
@@ -69,16 +82,16 @@ class ReliabilitySidecarTests(unittest.TestCase):
         self.assertEqual(
             "verified",
             restarted_sidecar.operation_state(
-                principal="customer-42",
+                caller_id="customer-42",
                 operation_key=operation_key,
             ),
         )
 
     def test_verified_retry_returns_cached_result(self) -> None:
         arguments = {
-            "principal": "customer-42",
-            "operation_key": "op-billing-ticket-0001",
-            "title": "Invoice is missing",
+            "caller_id": "customer-42",
+            "operation_key": "op-login-ticket-0001",
+            "title": "Cannot sign in",
         }
 
         first = self.sidecar.create_support_ticket(**arguments)
@@ -88,40 +101,120 @@ class ReliabilitySidecarTests(unittest.TestCase):
         self.assertEqual(1, self.ticket_service.ticket_count())
 
     def test_same_key_with_different_input_is_rejected(self) -> None:
-        operation_key = "op-profile-ticket-0001"
+        operation_key = "op-login-ticket-0001"
         self.sidecar.create_support_ticket(
-            principal="customer-42",
+            caller_id="customer-42",
             operation_key=operation_key,
-            title="Profile is unavailable",
+            title="Cannot sign in",
         )
 
         with self.assertRaises(OperationKeyConflict):
             self.sidecar.create_support_ticket(
-                principal="customer-42",
+                caller_id="customer-42",
                 operation_key=operation_key,
-                title="Delete my profile",
+                title="Cannot reset password",
             )
 
         self.assertEqual(1, self.ticket_service.ticket_count())
 
-    def test_existing_claim_without_evidence_does_not_repeat_effect(self) -> None:
-        operation_key = "op-active-claim-0001"
-        payload_digest = self.sidecar._payload_digest({"title": "Still processing"})
-        _, claim_created = self.sidecar._claim(
-            principal="customer-42",
+        conflicting_ticket_service = TicketService(
+            self.temporary_path / "conflicting-tickets.sqlite3"
+        )
+        conflicting_ticket_service.create_ticket(
+            caller_id="customer-42",
             operation_key=operation_key,
-            payload_digest=payload_digest,
+            title="Cannot reset password",
+        )
+        conflicting_sidecar = ReliabilitySidecar(
+            self.temporary_path / "conflicting-operations.sqlite3",
+            conflicting_ticket_service,
+        )
+
+        with self.assertRaises(ReconciliationConflict):
+            conflicting_sidecar.create_support_ticket(
+                caller_id="customer-42",
+                operation_key=operation_key,
+                title="Cannot sign in",
+            )
+
+    def test_existing_claim_without_evidence_does_not_repeat_effect(self) -> None:
+        operation_key = "op-login-ticket-0001"
+        input_hash = self.sidecar._input_hash({"title": "Cannot sign in"})
+        _, claim_created = self.sidecar._claim(
+            caller_id="customer-42",
+            operation_key=operation_key,
+            input_hash=input_hash,
         )
         self.assertTrue(claim_created)
 
         with self.assertRaises(OperationInProgress):
             self.sidecar.create_support_ticket(
-                principal="customer-42",
+                caller_id="customer-42",
                 operation_key=operation_key,
-                title="Still processing",
+                title="Cannot sign in",
             )
 
         self.assertEqual(0, self.ticket_service.ticket_count())
+
+    def test_concurrent_claims_admit_one_owner_without_state_regression(
+        self,
+    ) -> None:
+        operation_key = "op-login-ticket-0001"
+        input_hash = self.sidecar._input_hash({"title": "Cannot sign in"})
+        contenders = [
+            ReliabilitySidecar(
+                self.operation_database_path,
+                self.ticket_service,
+            )
+            for _ in range(2)
+        ]
+        start_together = Barrier(2)
+
+        def attempt_claim(sidecar: ReliabilitySidecar) -> bool:
+            start_together.wait(timeout=2)
+            _, claim_created = sidecar._claim(
+                caller_id="customer-42",
+                operation_key=operation_key,
+                input_hash=input_hash,
+            )
+            return claim_created
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(attempt_claim, contender) for contender in contenders
+            ]
+            claim_results = [future.result(timeout=5) for future in futures]
+
+        self.assertCountEqual([True, False], claim_results)
+
+        ticket = self.ticket_service.create_ticket(
+            caller_id="customer-42",
+            operation_key=operation_key,
+            title="Cannot sign in",
+        )
+        verified_result = contenders[0]._result(ticket, status="verified")
+        contenders[0]._mark_verified(
+            caller_id="customer-42",
+            operation_key=operation_key,
+            result=verified_result,
+        )
+
+        # The original owner finishes late. Its older "completed" update must
+        # not replace the "verified" state written by the retrying worker.
+        completed_result = contenders[1]._result(ticket, status="completed")
+        contenders[1]._mark_completed(
+            caller_id="customer-42",
+            operation_key=operation_key,
+            result=completed_result,
+        )
+
+        self.assertEqual(
+            "verified",
+            self.sidecar.operation_state(
+                caller_id="customer-42",
+                operation_key=operation_key,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,9 @@ effects, aligned with the final `2026-07-28` specification.
   final `2026-07-28` stateless request model, distinguishes OpenTelemetry
   observability from the deprecated MCP logging feature, and limits its
   generic retry example to read-only operations.
+- **Optional**: The lesson maps its portable concepts to one tagged community
+  implementation without making the hosted service or a network call part of
+  the exercise.
 
 [reliability-sidecar]: ./08-BestPractices/reliability-sidecars/README.md
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,22 +6,22 @@ This document serves as a record of all significant changes made to the Model Co
 
 ### New Module 08 Companion: Reliability Sidecars and Safe Retries
 
-Added a vendor-neutral companion lesson for effectful MCP tools, aligned with
-the `2026-07-28` release candidate while retaining a clear
-`2025-11-25`-current-version note.
+Added a vendor-neutral companion lesson for MCP tools that create real-world
+effects, aligned with the final `2026-07-28` specification.
 
 - **New**: The [reliability sidecar companion lesson][reliability-sidecar]
-  covers stable operation keys, atomic duplicate admission, durable lifecycle
-  records, reconciliation, evidence levels, the Tasks extension boundary, and
-  safe retry decisions.
+  uses one support-ticket story, two Mermaid diagrams, and a retry decision
+  flow to explain stable operation keys, atomic duplicate admission,
+  reconciliation, evidence, and the Tasks extension boundary.
 - **New**: A standard-library Python and SQLite failure-injection exercise
-  demonstrates a response lost after an external effect commits, plus
-  deterministic tests for naive duplication, guarded recovery, restart
-  recovery, payload conflicts, cached results, and active duplicate claims.
+  uses separate operation and ticket stores to demonstrate a response lost
+  after an external effect commits. Six deterministic tests cover naive
+  duplication, guarded restart recovery, payload conflicts, cached results,
+  active claims, and concurrent duplicate admission.
 - **Updated**: Module 08 now links the companion lesson, identifies the
-  `2026-07-28` stateless request model, distinguishes OpenTelemetry
-  observability from the deprecated MCP logging feature, and limits its generic
-  retry example to read-only operations.
+  final `2026-07-28` stateless request model, distinguishes OpenTelemetry
+  observability from the deprecated MCP logging feature, and limits its
+  generic retry example to read-only operations.
 
 [reliability-sidecar]: ./08-BestPractices/reliability-sidecars/README.md
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,29 @@
 
 This document serves as a record of all significant changes made to the Model Context Protocol (MCP) for Beginners curriculum. Changes are documented in reverse chronological order (newest changes first).
 
+## July 29th, 2026
+
+### New Module 08 Companion: Reliability Sidecars and Safe Retries
+
+Added a vendor-neutral companion lesson for effectful MCP tools, aligned with
+the `2026-07-28` release candidate while retaining a clear
+`2025-11-25`-current-version note.
+
+- **New**: The [reliability sidecar companion lesson][reliability-sidecar]
+  covers stable operation keys, atomic duplicate admission, durable lifecycle
+  records, reconciliation, evidence levels, the Tasks extension boundary, and
+  safe retry decisions.
+- **New**: A standard-library Python and SQLite failure-injection exercise
+  demonstrates a response lost after an external effect commits, plus
+  deterministic tests for naive duplication, guarded recovery, restart
+  recovery, payload conflicts, cached results, and active duplicate claims.
+- **Updated**: Module 08 now links the companion lesson, identifies the
+  `2026-07-28` stateless request model, distinguishes OpenTelemetry
+  observability from the deprecated MCP logging feature, and limits its generic
+  retry example to read-only operations.
+
+[reliability-sidecar]: ./08-BestPractices/reliability-sidecars/README.md
+
 ## July 2nd, 2026
 
 ### New Lesson: The 2026-07-28 MCP Specification Release Candidate


### PR DESCRIPTION
Closes #949.

## Summary

- Revises the Module 08 safe-retry draft into a concise, story-led lesson aligned with the final MCP 2026-07-28 specification.
- Adds two accessible Mermaid diagrams and an identifier table that distinguish JSON-RPC request IDs, Task IDs, operation keys, and destination ticket IDs.
- Adds a deterministic, standard-library-only Python exercise with separate SQLite stores and six failure-injection tests.
- Keeps MCP Tasks separate from business-effect idempotency and describes the reliability sidecar as application code, not an MCP feature.
- Updates only the branch-introduced Module 08 lesson, its parent links, retry/observability guidance, and the changelog.

The required lesson and exercise are local, offline, vendor-neutral, and make no network calls.

## Optional community reference and disclosure

The final lesson contains an optional reference to Agent Enhancer Utilities as one community implementation of the application-level pattern. It is not required for the lesson and is not presented as part of MCP or as evidence of MCP 2026-07-28 compatibility.

I maintain/contribute to Agent Enhancer Utilities. The optional callout is isolated in commit `f134ac99d`, so maintainers can omit it without changing the standalone lesson or exercise.

## Validation

- All six Python unit tests pass.
- Ruff check and format-check pass without unrelated rewrites.
- Both Python files parse against the repository's Python 3.8 baseline.
- Focused Markdown lint passes; parent/changelog edits introduce no new diagnostics.
- Both Mermaid diagrams render successfully and were inspected at narrow width in dark mode.
- Relative links and immutable external references were verified.
- `git diff --check` passes.
- No translations or translated images changed.
- The local exercise contains no network calls.
