### PR TITLE
Add MiniMax model options to the Java client

### DIFF
--- a/03-GettingStarted/03-llm-client/solution/java/README.md
+++ b/03-GettingStarted/03-llm-client/solution/java/README.md
@@ -1,49 +1,47 @@
 # Calculator LLM Client
 
-A Java application that demonstrates how to use LangChain4j to connect to an MCP (Model Context Protocol) calculator service with GitHub Models integration.
+A Java application that demonstrates how to use LangChain4j to connect to an MCP (Model Context Protocol) calculator service through the MiniMax OpenAI-compatible API.
 
 ## Prerequisites
 
 - Java 21 or higher
 - Maven 3.6+ (or use the included Maven wrapper)
-- A GitHub account with access to GitHub Models
+- A MiniMax API key
 - An MCP calculator service running on `http://localhost:8080`
 
-## Getting the GitHub Token
+## Getting the API Key
 
-This application uses GitHub Models which requires a GitHub personal access token. Follow these steps to get your token:
+This application uses the MiniMax OpenAI-compatible API. Follow these steps to get your key and endpoint:
 
-### 1. Access GitHub Models
-1. Go to [GitHub Models](https://github.com/marketplace/models)
-2. Sign in with your GitHub account
-3. Request access to GitHub Models if you haven't already
+### 1. Choose an endpoint
+1. Use `https://api.minimax.io/v1` for the global endpoint
+2. Use `https://api.minimaxi.com/v1` for the China endpoint
 
-### 2. Create a Personal Access Token
-1. Go to [GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens)
-2. Click "Generate new token" → "Generate new token (classic)"
-3. Give your token a descriptive name (e.g., "MCP Calculator Client")
-4. Set expiration as needed
-5. Select the following scopes:
-   - `repo` (if accessing private repositories)
-   - `user:email`
-6. Click "Generate token"
-7. **Important**: Copy the token immediately - you won't be able to see it again!
+### 2. Create an API key
+1. Create a MiniMax API key from your MiniMax account
+2. Keep the key somewhere secure
 
-### 3. Set the Environment Variable
+### 3. Set the Environment Variables
 
 #### On Windows (Command Prompt):
 ```cmd
-set GITHUB_TOKEN=your_github_token_here
+set OPENAI_API_KEY=your_minimax_api_key_here
+set OPENAI_BASE_URL=https://api.minimax.io/v1
+set MINIMAX_MODEL_ID=MiniMax-M3
 ```
 
 #### On Windows (PowerShell):
 ```powershell
-$env:GITHUB_TOKEN="your_github_token_here"
+$env:OPENAI_API_KEY="your_minimax_api_key_here"
+$env:OPENAI_BASE_URL="https://api.minimax.io/v1"
+$env:MINIMAX_MODEL_ID="MiniMax-M3"
 ```
 
 #### On macOS/Linux:
 ```bash
-export GITHUB_TOKEN=your_github_token_here
+export OPENAI_API_KEY=your_minimax_api_key_here
+export OPENAI_BASE_URL=https://api.minimax.io/v1
+export MINIMAX_MODEL_ID=MiniMax-M3
 ```
 
 ## Setup and Installation
@@ -59,7 +57,7 @@ export GITHUB_TOKEN=your_github_token_here
    mvn clean install
    ```
 
-3. **Set up the environment variable** (see "Getting the GitHub Token" section above)
+3. **Set up the environment variables** (see "Getting the API Key" section above)
 
 4. **Start the MCP Calculator Service**:
    Make sure you have chapter 1's MCP calculator service running on `http://localhost:8080/sse`. This should be running before you start the client.
@@ -93,8 +91,8 @@ The calculator service provides the following functions: add, subtract, multiply
 
 ### Common Issues
 
-1. **"GITHUB_TOKEN environment variable not set"**
-   - Make sure you've set the `GITHUB_TOKEN` environment variable
+1. **"OPENAI_API_KEY environment variable not set"**
+   - Make sure you've set the `OPENAI_API_KEY` environment variable
    - Restart your terminal/command prompt after setting the variable
 
 2. **"Connection refused to localhost:8080"**
@@ -102,8 +100,8 @@ The calculator service provides the following functions: add, subtract, multiply
    - Check if another service is using port 8080
 
 3. **"Authentication failed"**
-   - Verify your GitHub token is valid and has the correct permissions
-   - Check if you have access to GitHub Models
+   - Verify your API key is valid
+   - Check that `OPENAI_BASE_URL` matches the endpoint you intended to use
 
 4. **Maven build errors**
    - Ensure you're using Java 21 or higher: `java -version`
@@ -119,17 +117,17 @@ java -Dlogging.level.dev.langchain4j=DEBUG -jar target\calculator-llm-client-0.0
 ## Configuration
 
 The application is configured to:
-- Use GitHub Models with the `gpt-4.1-nano` model
+- Use MiniMax-M3 by default, or MiniMax-M2.7 when `MINIMAX_MODEL_ID` is set
+- Connect to `https://api.minimax.io/v1` by default, or `https://api.minimaxi.com/v1` when `MINIMAX_REGION=cn_zh`
 - Connect to MCP service at `http://localhost:8080/sse`
 - Use a 60-second timeout for requests
-- Enable request/response logging for debugging
 
 ## Dependencies
 
 Key dependencies used in this project:
 - **LangChain4j**: For AI integration and tool management
 - **LangChain4j MCP**: For Model Context Protocol support
-- **LangChain4j GitHub Models**: For GitHub Models integration
+- **LangChain4j OpenAI official**: For MiniMax OpenAI-compatible API integration
 - **Spring Boot**: For application framework and dependency injection
 
 ## License

--- a/03-GettingStarted/03-llm-client/solution/java/README.md
+++ b/03-GettingStarted/03-llm-client/solution/java/README.md
@@ -118,7 +118,7 @@ java -Dlogging.level.dev.langchain4j=DEBUG -jar target\calculator-llm-client-0.0
 
 The application is configured to:
 - Use MiniMax-M3 by default, or MiniMax-M2.7 when `MINIMAX_MODEL_ID` is set
-- Connect to `https://api.minimax.io/v1` by default, or `https://api.minimaxi.com/v1` when `MINIMAX_REGION=cn_zh`
+- Connect to `OPENAI_BASE_URL` when it is set; otherwise use `https://api.minimaxi.com/v1` when `MINIMAX_REGION=cn_zh`, or `https://api.minimax.io/v1` by default
 - Connect to MCP service at `http://localhost:8080/sse`
 - Use a 60-second timeout for requests
 

--- a/03-GettingStarted/03-llm-client/solution/java/README.md
+++ b/03-GettingStarted/03-llm-client/solution/java/README.md
@@ -91,7 +91,7 @@ The calculator service provides the following functions: add, subtract, multiply
 
 ### Common Issues
 
-1. **"OPENAI_API_KEY environment variable not set"**
+1. **"OPENAI_API_KEY environment variable is not set"**
    - Make sure you've set the `OPENAI_API_KEY` environment variable
    - Restart your terminal/command prompt after setting the variable
 

--- a/03-GettingStarted/03-llm-client/solution/java/src/main/java/com/microsoft/mcp/sample/client/LangChain4jClient.java
+++ b/03-GettingStarted/03-llm-client/solution/java/src/main/java/com/microsoft/mcp/sample/client/LangChain4jClient.java
@@ -11,17 +11,26 @@ import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.ToolProvider;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
 import java.util.List;
 
 public class LangChain4jClient {
 
+        private static final String DEFAULT_BASE_URL = "https://api.minimax.io/v1";
+        private static final String DEFAULT_MODEL_ID = "MiniMax-M3";
+        private static final Map<String, String> REGIONAL_BASE_URLS = Map.of(
+                        "global_en", "https://api.minimax.io/v1",
+                        "cn_zh", "https://api.minimaxi.com/v1");
+        private static final Set<String> SUPPORTED_MODEL_IDS = Set.of("MiniMax-M3", "MiniMax-M2.7");
+
         public static void main(String[] args) throws Exception {
 
                 ChatLanguageModel model = OpenAiOfficialChatModel.builder()
-                                .isGitHubModels(true)
-                                .apiKey(System.getenv("GITHUB_TOKEN"))
+                                .baseUrl(resolveBaseUrl())
+                                .apiKey(requireEnv("OPENAI_API_KEY"))
                                 .timeout(Duration.ofSeconds(60))
-                                .modelName("gpt-4.1-mini")
+                                .modelName(resolveModelName())
                                 .build();
 
                 McpTransport transport = new HttpMcpTransport.Builder()
@@ -55,5 +64,42 @@ public class LangChain4jClient {
                 } finally {
                         mcpClient.close();
                 }
+        }
+
+        private static String resolveBaseUrl() {
+                String baseUrl = System.getenv("OPENAI_BASE_URL");
+                if (baseUrl != null && !baseUrl.isBlank()) {
+                        return baseUrl;
+                }
+
+                String region = System.getenv("MINIMAX_REGION");
+                if (region == null || region.isBlank()) {
+                        return DEFAULT_BASE_URL;
+                }
+
+                String regionalBaseUrl = REGIONAL_BASE_URLS.get(region);
+                if (regionalBaseUrl == null) {
+                        throw new IllegalArgumentException("Unsupported MINIMAX_REGION value: " + region);
+                }
+                return regionalBaseUrl;
+        }
+
+        private static String resolveModelName() {
+                String modelId = System.getenv("MINIMAX_MODEL_ID");
+                if (modelId == null || modelId.isBlank()) {
+                        return DEFAULT_MODEL_ID;
+                }
+                if (!SUPPORTED_MODEL_IDS.contains(modelId)) {
+                        throw new IllegalArgumentException("Unsupported MINIMAX_MODEL_ID value: " + modelId);
+                }
+                return modelId;
+        }
+
+        private static String requireEnv(String name) {
+                String value = System.getenv(name);
+                if (value == null || value.isBlank()) {
+                        throw new IllegalStateException(name + " environment variable is not set");
+                }
+                return value;
         }
 }


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 support with global and China OpenAI-compatible endpoints in the Java client.

Changes:
- Switched the Java client to `OPENAI_API_KEY` and `OPENAI_BASE_URL`.
- Added `MINIMAX_MODEL_ID` and `MINIMAX_REGION` handling with MiniMax-M3 as the default.
- Updated the sample README with the new setup, endpoint, and model options.

Checks:
- `git diff --check`
- Secret scan with the provided regex found no matches.
