### PR TITLE
Update Python server import and initialization

### DIFF
--- a/03-GettingStarted/01-first-server/README.md
+++ b/03-GettingStarted/01-first-server/README.md
@@ -509,10 +509,10 @@ Now you have a server, but it doesn't do much, let' fix that.
 
 ```python
 # server.py
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 # Create an MCP server
-mcp = FastMCP("Demo")
+mcp = MCPServer("Demo")
 ```
 
 #### .NET


### PR DESCRIPTION
FastMCP was renamed to MCPServer and mcp.server.fastmcp was removed in the 2.x SDK. Tutorial was written for the 1.x SDK and still used from mcp.server.fastmcp import FastMCP