### PR TITLE
[Module 03] Fix Windows virtual environment path

### DIFF
--- a/03-GettingStarted/02-client/solution/python/README.md
+++ b/03-GettingStarted/02-client/solution/python/README.md
@@ -11,7 +11,7 @@ python -m venv venv
 ## -1- Activate the virtual environment
 
 ```bash
-venv\Scrips\activate
+venv\Scripts\activate
 ```
 
 ## -2- Install the dependencies
@@ -21,7 +21,6 @@ pip install "mcp[cli]"
 ```
 
 ## -3- Run the sample
-
 
 ```bash
 python client.py
@@ -34,12 +33,12 @@ LISTING RESOURCES
 Resource:  ('meta', None)
 Resource:  ('nextCursor', None)
 Resource:  ('resources', [])
-                    INFO     Processing request of type ListToolsRequest                                                                               server.py:534
+INFO Processing request of type ListToolsRequest server.py:534
 LISTING TOOLS
 Tool:  add
 READING RESOURCE
-                    INFO     Processing request of type ReadResourceRequest                                                                            server.py:534
+INFO Processing request of type ReadResourceRequest server.py:534
 CALL TOOL
-                    INFO     Processing request of type CallToolRequest                                                                                server.py:534
+INFO Processing request of type CallToolRequest server.py:534
 [TextContent(type='text', text='8', annotations=None)]
 ```


### PR DESCRIPTION
# Purpose

Correct the Windows virtual-environment activation command so learners use the existing `Scripts` directory instead of the misspelled `Scrips` path. The nearby sample output and blank spacing are also normalized so the changed README passes the repository's Markdown lint command.

Closes #1038

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Validation

- `npx --yes markdownlint-cli2 03-GettingStarted/02-client/solution/python/README.md` (0 errors)
- Verified the corrected `venv\\Scripts\\activate` command is present and the misspelled path is absent.
