### PR TITLE
[Module 03] Add a hosted MCP search exercise

### DIFF
--- a/03-GettingStarted/06-http-streaming/README.md
+++ b/03-GettingStarted/06-http-streaming/README.md
@@ -229,6 +229,82 @@ In MCP, streaming is not about sending the main response in chunks, but about se
 
 The main result is still sent as a single response. However, notifications can be sent as separate messages during processing and thereby update the client in real time. The client must be able to handle and display these notifications.
 
+### Optional exercise: connect to a hosted MCP server
+
+You can also use Streamable HTTP without running a local server. This example
+connects to [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp),
+discovers its tools, and searches for public MCP documentation using the same
+Python SDK as the [local client](./solution/python/client.py).
+
+Parallel's anonymous endpoint requires no account or API key. Free access is
+rate limited. Running this script sends the search queries, objective, and a
+random session identifier to Parallel. The service also offers `web_fetch`,
+which sends requested URLs and any supplied context to Parallel. Use public
+information for this exercise; see its [terms](https://parallel.ai/customer-terms)
+and [privacy policy](https://parallel.ai/privacy-policy).
+
+With Python 3.10 or newer and a virtual environment activated, install the SDK:
+
+```sh
+python -m pip install "mcp>=1.10,<2"
+```
+
+Save this as `hosted_search.py` and run `python hosted_search.py`:
+
+```python
+import asyncio
+from uuid import uuid4
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+
+async def main() -> None:
+    async with streamablehttp_client("https://search.parallel.ai/mcp") as (
+        read_stream,
+        write_stream,
+        _,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            print("Available tools:", [tool.name for tool in tools.tools])
+
+            result = await session.call_tool(
+                "web_search",
+                {
+                    "objective": "Find the official MCP Streamable HTTP documentation",
+                    "search_queries": ["MCP Streamable HTTP documentation"],
+                    "session_id": str(uuid4()),
+                },
+            )
+            if result.isError:
+                raise RuntimeError(f"Search tool failed: {result.content}")
+            for block in result.content:
+                if block.type == "text":
+                    print(block.text)
+
+
+async def run() -> None:
+    await asyncio.wait_for(main(), timeout=60)
+
+
+asyncio.run(run())
+```
+
+Expect discovery to include `web_search` and `web_fetch`, followed by a search
+response containing source URLs and excerpts. Results can vary or be empty.
+The script checks `isError` because a tool can fail even when the HTTP request
+succeeds. If access is rate limited, wait before trying again. Reuse the same
+`session_id` if you extend the script with related search or fetch calls.
+
+Streamable HTTP permits both JSON and SSE responses; this server can return a
+complete JSON result without progress notifications. The SDK handles the
+transport. Continue with the local example below to learn about notifications.
+This optional script makes one explicit search and closes its connection when
+it finishes. If you later expose these tools to an agent, the agent may invoke
+them during its work; treat retrieved web text as untrusted data.
+
 ## What is a Notification?
 
 We said "Notification", what does that mean in the context of MCP?

--- a/03-GettingStarted/06-http-streaming/README.md
+++ b/03-GettingStarted/06-http-streaming/README.md
@@ -260,6 +260,7 @@ from mcp.client.streamable_http import streamablehttp_client
 
 
 async def main() -> None:
+    session_id = str(uuid4())
     async with streamablehttp_client("https://search.parallel.ai/mcp") as (
         read_stream,
         write_stream,
@@ -275,7 +276,7 @@ async def main() -> None:
                 {
                     "objective": "Find the official MCP Streamable HTTP documentation",
                     "search_queries": ["MCP Streamable HTTP documentation"],
-                    "session_id": str(uuid4()),
+                    "session_id": session_id,
                 },
             )
             if result.isError:
@@ -289,7 +290,8 @@ async def run() -> None:
     await asyncio.wait_for(main(), timeout=60)
 
 
-asyncio.run(run())
+if __name__ == "__main__":
+    asyncio.run(run())
 ```
 
 Expect discovery to include `web_search` and `web_fetch`, followed by a search


### PR DESCRIPTION
# Purpose

Adds an optional hosted-server exercise to the HTTP streaming lesson. Learners can initialize a remote MCP connection, discover tools, and run a public web search without running a local server or getting an API key.

The Python example uses the same MCP SDK as the local solution. It checks tool errors and explains that Streamable HTTP can return JSON without progress notifications. Existing local examples stay unchanged. The exercise documents the data sent to Parallel, free-access limits, and how agent use differs from the explicit call in this script.

The existing [web-search example uses SerpAPI](https://github.com/microsoft/mcp-for-beginners/blob/422055c27bf1e0fc3b932e87c437a2bfa0cd17ae/05-AdvancedTopics/web-search-mcp/server.py#L32-L40). Artificial Analysis doesn't benchmark SerpAPI, so there's no direct comparison available for that example.

For some context on Parallel itself, [Artificial Analysis's August 31 results](https://artificialanalysis.ai/agents/search-api) give Parallel fast **80.2 F1 on DeepSearchQA** and **19.2 seconds average time per task**. Those results are for the Search API in AA's fixed harness. The [time-per-task figure](https://artificialanalysis.ai/methodology/search-api) includes model time plus search time; it isn't a measurement of this MCP lesson. The example uses the [anonymous MCP endpoint's fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp), so fast is the relevant API result to look at.

I work at Parallel, which operates this service.

## Validation

- Executed the exact fenced Python example anonymously with MCP SDK 1.10.0 and 1.29.1. Both discovered `web_search` and `web_fetch` and returned search results with source URLs and excerpts.
- The added section passes Markdown lint and renders with the intended shell and Python blocks. The full lesson has the same 105 lint findings as the unmodified base.
- Checked the added public links and `git diff --check`.
- No repository build or full sample suite ran. This exercise calls search only; it does not exercise fetch or progress notifications.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Does this require changes to learn.microsoft.com docs or modules?

- [ ] Yes
- [x] No

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other

