### PR TITLE
[Module 03] Show how to connect a hosted Streamable HTTP server in the MCP hosts lesson

### DIFF
--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -307,7 +307,7 @@ Windsurf configuration is managed through the settings UI:
 
 ## Connecting to a Remote Server
 
-Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so instead of a command you give the host the server's URL (each host has its own field for it, shown below) and it talks to the server over Streamable HTTP. The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
+Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so instead of a command you give the host the server's URL (each host has its own field for it, shown below). MCP has two remote transports: the older SSE transport, which is what the VS Code example earlier in this lesson configures with `"type": "sse"` and an `/sse` URL, and the current Streamable HTTP transport, which uses a single `/mcp` URL and is what the server below speaks (`"type": "http"` in VS Code). The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
 
 **VS Code** (`.vscode/mcp.json`):
 
@@ -334,7 +334,7 @@ Every example above starts a local server with `command` and `args`. A remote se
 }
 ```
 
-**Cline** (MCP Servers icon → Configure → Configure MCP Servers):
+**Cline** (the VS Code extension; the MCP Servers panel → Configure MCP Servers button opens its `cline_mcp_settings.json`). The CLI flags shown earlier in this lesson start local servers; a remote server is added through this file:
 
 ```json
 {
@@ -347,7 +347,7 @@ Every example above starts a local server with `command` and `args`. A remote se
 }
 ```
 
-**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+**Windsurf** (`~/.codeium/windsurf/mcp_config.json`; this is the file that Settings → Cascade → MCP Servers → "View raw config" opens, separate from the editor's `settings.json` shown earlier):
 
 ```json
 {
@@ -361,7 +361,7 @@ Every example above starts a local server with `command` and `args`. A remote se
 
 Claude Desktop does not read an HTTP entry from its configuration file (see the table below), so this example skips it.
 
-After you save the file and reload the host, check its tool list: once the connection succeeds it shows two tools, `search_web_pages` (search the web) and `fetch_page_content` (read a page). If they do not show up, look at the host's MCP output for a connection or rate-limit error before changing the configuration. Then ask something like "Search the web for the latest MCP specification release" and the assistant should call `search_web_pages`.
+After you save the file and reload the host, check its tool list: once the connection succeeds, the server's tools appear there (at the time of writing, a web search tool and a page fetch tool). If nothing shows up, look at the host's MCP output for a connection or rate-limit error before changing the configuration. Then ask something like "Search the web for the latest MCP specification release" and the assistant should call the search tool.
 
 ---
 
@@ -369,7 +369,7 @@ After you save the file and reload the host, check its tool list: once the conne
 
 Different hosts support different transport mechanisms:
 
-| Host | stdio | SSE/HTTP | WebSocket |
+| Host | stdio | SSE / Streamable HTTP | WebSocket |
 |------|-------|----------|-----------|
 | Claude Desktop | ✅ | ❌ | ❌ |
 | VS Code | ✅ | ✅ | ❌ |
@@ -378,9 +378,9 @@ Different hosts support different transport mechanisms:
 | Windsurf | ✅ | ✅ | ❌ |
 
 **stdio** (standard input/output): Best for local servers started by the host
-**SSE/HTTP**: Best for remote servers or servers shared between multiple clients
+**SSE / Streamable HTTP**: Best for remote servers or servers shared between multiple clients (Streamable HTTP is the current remote transport; SSE is its predecessor and is still accepted by most hosts)
 
-See [Connecting to a Remote Server](#connecting-to-a-remote-server) above for an HTTP configuration example for the hosts that support it.
+See [Connecting to a Remote Server](#connecting-to-a-remote-server) above for a Streamable HTTP configuration example for the hosts that support it.
 
 ---
 

--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -307,7 +307,7 @@ Windsurf configuration is managed through the settings UI:
 
 ## Connecting to a Remote Server
 
-Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so instead of a command you give the host the server's URL (each host has its own field for it, shown below). MCP has two remote transports: the older SSE transport, which is what the VS Code example earlier in this lesson configures with `"type": "sse"` and an `/sse` URL, and the current Streamable HTTP transport, which uses a single `/mcp` URL and is what the server below speaks (`"type": "http"` in VS Code). The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
+Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so instead of a command you give the host the server's URL (each host has its own field for it, shown below). For HTTP-based remote connections, MCP has two transports: the older SSE transport (what the VS Code example earlier in this lesson configures with `"type": "sse"` and an `/sse` URL) and the current Streamable HTTP transport (configured with `"type": "http"` in VS Code), which typically uses a single endpoint URL (often `/mcp`). The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
 
 **VS Code** (`.vscode/mcp.json`):
 

--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -361,7 +361,7 @@ Every example above starts a local server with `command` and `args`. A remote se
 
 Claude Desktop does not read an HTTP entry from its configuration file (see the table below), so this example skips it.
 
-After you save the file and reload the host, check its tool list: once the connection succeeds, the server's tools appear there (at the time of writing, a web search tool and a page fetch tool). If nothing shows up, look at the host's MCP output for a connection or rate-limit error before changing the configuration. Then ask something like "Search the web for the latest MCP specification release" and the assistant should call the search tool.
+After you save the file and reload the host, check its tool list: once the connection succeeds, the server's tools appear there. If nothing shows up, look at the host's MCP output for a connection or rate-limit error before changing the configuration. Then ask a question that needs one of the listed tools and the assistant should call it.
 
 ---
 

--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -305,6 +305,66 @@ Windsurf configuration is managed through the settings UI:
 
 ---
 
+## Connecting to a Remote Server
+
+Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so the host only needs its URL and talks to it over Streamable HTTP. The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
+
+**VS Code** (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "keenable": {
+      "type": "http",
+      "url": "https://api.keenable.ai/mcp"
+    }
+  }
+}
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "keenable": {
+      "url": "https://api.keenable.ai/mcp"
+    }
+  }
+}
+```
+
+**Cline** (MCP Servers icon → Configure → Configure MCP Servers):
+
+```json
+{
+  "mcpServers": {
+    "keenable": {
+      "type": "streamableHttp",
+      "url": "https://api.keenable.ai/mcp"
+    }
+  }
+}
+```
+
+**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "keenable": {
+      "serverUrl": "https://api.keenable.ai/mcp"
+    }
+  }
+}
+```
+
+Claude Desktop does not read an HTTP entry from its configuration file (see the table below), so this example skips it.
+
+After you save the file and reload the host, two tools should appear in its tool list: `search_web_pages` (search the web) and `fetch_page_content` (read a page). Ask something like "Search the web for the latest MCP specification release" and the assistant should call `search_web_pages`.
+
+---
+
 ## Transport Types Comparison
 
 Different hosts support different transport mechanisms:
@@ -319,6 +379,8 @@ Different hosts support different transport mechanisms:
 
 **stdio** (standard input/output): Best for local servers started by the host
 **SSE/HTTP**: Best for remote servers or servers shared between multiple clients
+
+See [Connecting to a Remote Server](#connecting-to-a-remote-server) above for a working HTTP configuration in each host.
 
 ---
 
@@ -386,3 +448,4 @@ Different hosts support different transport mechanisms:
 - [VS Code MCP Extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-mcp)
 - [MCP Specification - Transports](https://spec.modelcontextprotocol.io/specification/2025-11-25/basic/transports/)
 - [Official MCP Servers Registry](https://github.com/modelcontextprotocol/servers)
+- [Keenable Hosted MCP Server](https://docs.keenable.ai/mcp-server)

--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -307,7 +307,7 @@ Windsurf configuration is managed through the settings UI:
 
 ## Connecting to a Remote Server
 
-Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so the host only needs its URL and talks to it over Streamable HTTP. The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
+Every example above starts a local server with `command` and `args`. A remote server is already running somewhere else, so instead of a command you give the host the server's URL (each host has its own field for it, shown below) and it talks to the server over Streamable HTTP. The snippets below use the hosted MCP server from [Keenable](https://keenable.ai) at `https://api.keenable.ai/mcp`, which is free to use without an account or API key; anonymous requests are rate limited per IP.
 
 **VS Code** (`.vscode/mcp.json`):
 
@@ -361,7 +361,7 @@ Every example above starts a local server with `command` and `args`. A remote se
 
 Claude Desktop does not read an HTTP entry from its configuration file (see the table below), so this example skips it.
 
-After you save the file and reload the host, two tools should appear in its tool list: `search_web_pages` (search the web) and `fetch_page_content` (read a page). Ask something like "Search the web for the latest MCP specification release" and the assistant should call `search_web_pages`.
+After you save the file and reload the host, check its tool list: once the connection succeeds it shows two tools, `search_web_pages` (search the web) and `fetch_page_content` (read a page). If they do not show up, look at the host's MCP output for a connection or rate-limit error before changing the configuration. Then ask something like "Search the web for the latest MCP specification release" and the assistant should call `search_web_pages`.
 
 ---
 
@@ -380,7 +380,7 @@ Different hosts support different transport mechanisms:
 **stdio** (standard input/output): Best for local servers started by the host
 **SSE/HTTP**: Best for remote servers or servers shared between multiple clients
 
-See [Connecting to a Remote Server](#connecting-to-a-remote-server) above for a working HTTP configuration in each host.
+See [Connecting to a Remote Server](#connecting-to-a-remote-server) above for an HTTP configuration example for the hosts that support it.
 
 ---
 


### PR DESCRIPTION
# Purpose

Lesson 3.12 (Setting Up Popular MCP Host Clients) configures a local stdio server in every host example, and the Transport Types table says SSE/HTTP is "best for remote servers" without showing one. This adds a short "Connecting to a Remote Server" section with the HTTP entry for VS Code, Cursor, Cline and Windsurf, each in the shape that host's current documentation uses (`servers` + `type: "http"` in VS Code, `url` only in Cursor, `type: "streamableHttp"` in Cline, `serverUrl` in Windsurf), a note that Claude Desktop's config file has no HTTP transport, and two sentences on what the reader should see afterwards. The Transport Types section gets one pointer line and Additional Resources one link.

The example server is Keenable's hosted MCP server (`https://api.keenable.ai/mcp`), chosen because it needs no account or API key, so a reader can complete the step without signing up anywhere. It is rate limited per IP when used anonymously. I work at Keenable.

Nothing under `translations/` is touched; the localization bot syncs those.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
