### PR TITLE
Fix typo in .NET and MCP server instructions

### DIFF
--- a/translations/ja/03-GettingStarted/README.md
+++ b/translations/ja/03-GettingStarted/README.md
@@ -90,7 +90,7 @@ MCPは複数言語向けに公式SDKを提供しています（[MCP仕様 2025-1
 このセクションのすべての章で行う演習を補完するサンプルセットがあります。さらに各章には独自の演習と課題もあります。
 
 - [Java 計算機](./samples/java/calculator/README.md)
-- [.Net 計算機](../../../03-GettingStarted/samples/csharp)
+- [.NET 計算機](../../../03-GettingStarted/samples/csharp)
 - [JavaScript 計算機](./samples/javascript/README.md)
 - [TypeScript 計算機](./samples/typescript/README.md)
 - [Python 計算機](../../../03-GettingStarted/samples/python)
@@ -103,7 +103,7 @@ MCPは複数言語向けに公式SDKを提供しています（[MCP仕様 2025-1
 
 ## 次に進むべきこと
 
-最初のレッスンから始めましょう：[あなたの最初のMCPサーバーを作成する](01-first-server/README.md)
+最初のレッスンから始めましょう：[はじめてのMCPサーバーを作成する](01-first-server/README.md)
 
 このモジュールを完了したら、次に以下を続けてください：[モジュール4：実践的な実装](../04-PracticalImplementation/README.md)
 


### PR DESCRIPTION
https://github.com/microsoft/mcp-for-beginners/blob/main/translations/ja/03-GettingStarted/README.md 

<img width="1185" height="244" alt="image" src="https://github.com/user-attachments/assets/434d53af-a30c-4871-aa2d-c1cfcab2dee2" />

related https://github.com/microsoft/mcp-for-beginners/pull/1054

#PingMSFTDocs