### PR TITLE
Fix typo in .NET Calculator link

### DIFF
--- a/translations/ja/03-GettingStarted/01-first-server/README.md
+++ b/translations/ja/03-GettingStarted/01-first-server/README.md
@@ -1346,7 +1346,7 @@ MCP は複数言語の公式 SDK を提供しています：
 ## サンプル
 
 - [Java Calculator](../samples/java/calculator/README.md)
-- [.Net Calculator](../../../../03-GettingStarted/samples/csharp)
+- [.NET Calculator](../../../../03-GettingStarted/samples/csharp)
 - [JavaScript Calculator](../samples/javascript/README.md)
 - [TypeScript Calculator](../samples/typescript/README.md)
 - [Python Calculator](../../../../03-GettingStarted/samples/python)


### PR DESCRIPTION
https://github.com/microsoft/mcp-for-beginners/blob/main/translations/ja/03-GettingStarted/01-first-server/README.md 

<img width="1195" height="54" alt="image" src="https://github.com/user-attachments/assets/2c861293-ab32-434d-909c-f20eaf296581" />

#PingMSFTDocs