### PR TITLE
Fix capitalization of '.NET' in README.md

### DIFF
--- a/03-GettingStarted/02-client/README.md
+++ b/03-GettingStarted/02-client/README.md
@@ -897,7 +897,7 @@ The key takeaways for this chapter is the following about clients:
 ## Samples
 
 - [Java Calculator](../samples/java/calculator/README.md)
-- [.Net Calculator](../samples/csharp/)
+- [.NET Calculator](../samples/csharp/)
 - [JavaScript Calculator](../samples/javascript/README.md)
 - [TypeScript Calculator](../samples/typescript/README.md)
 - [Python Calculator](../samples/python/)


### PR DESCRIPTION
https://github.com/microsoft/mcp-for-beginners/blob/main/03-GettingStarted/02-client/README.md 

<img width="1177" height="53" alt="image" src="https://github.com/user-attachments/assets/4fb18cb3-df34-44f6-acb3-43c5d6263f1e" />

#PingMSFTDocs