### PR TITLE
Aug Update

### DIFF
--- a/00-Introduction/README.md
+++ b/00-Introduction/README.md
@@ -72,15 +72,22 @@ MCP follows a **client-server model**, where:
 - **Resources** – Static or dynamic data for models  
 - **Prompts** – Predefined workflows for guided generation  
 - **Tools** – Executable functions like search, calculations  
-- **Sampling** – Agentic behavior via recursive interactions (deprecated in `2026-07-28` release candidate)
+- **Sampling** – Agentic behavior via recursive interactions (deprecated in
+    MCP `2026-07-28`; new implementations should integrate directly with an LLM
+    provider)
 - **Elicitation** – Server-initiated requests for user input
-- **Roots** – Filesystem boundaries for server access control (deprecated in `2026-07-28` release candidate)
+- **Roots** – Informational filesystem locations relevant to a server
+    (deprecated in MCP `2026-07-28`; prefer tool parameters, resource URIs, or
+    server configuration)
 
 ### **Protocol Architecture:**
 
 MCP uses a two-layer architecture:
-- **Data Layer**: JSON-RPC 2.0 based communication with lifecycle management and primitives
-- **Transport Layer**: STDIO (local) and Streamable HTTP with SSE (remote) communication channels
+- **Data Layer**: JSON-RPC 2.0 messages, per-request metadata, discovery, and
+    protocol primitives
+- **Transport Layer**: stdio for local subprocesses and Streamable HTTP for
+    remote servers. Streamable HTTP can use SSE framing for streamed responses,
+    but the older HTTP+SSE transport is deprecated.
 
 ---
 

--- a/01-CoreConcepts/README.md
+++ b/01-CoreConcepts/README.md
@@ -7,13 +7,21 @@ _(Click the image above to view video of this lesson)_
 The [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) is a powerful, standardized framework that optimizes communication between Large Language Models (LLMs) and external tools, applications, and data sources. 
 This guide will walk you through the core concepts of MCP. You will learn about its client-server architecture, essential components, communication mechanics, and implementation best practices.
 
-- **Explicit User Consent**: All data access and operations require explicit user approval before execution. Users must clearly understand what data will be accessed and what actions will be performed, with granular control over permissions and authorizations.
+- **User Control and Consent**: Hosts should clearly show what data and tools a
+  server exposes, let users deny operations, and obtain explicit confirmation
+  for sensitive or consequential actions. MCP does not require a confirmation
+  dialog before every tool call.
 
 - **Data Privacy Protection**: User data is only exposed with explicit consent and must be protected by robust access controls throughout the entire interaction lifecycle. Implementations must prevent unauthorized data transmission and maintain strict privacy boundaries.
 
-- **Tool Execution Safety**: Every tool invocation requires explicit user consent with clear understanding of the tool's functionality, parameters, and potential impact. Robust security boundaries must prevent unintended, unsafe, or malicious tool execution.
+- **Tool Execution Safety**: Hosts should make tool invocations visible and keep
+  a human able to deny them. Sensitive operations should show the tool inputs
+  and impact before execution, with security boundaries that prevent unintended
+  or malicious actions.
 
-- **Transport Layer Security**: All communication channels should use appropriate encryption and authentication mechanisms. Remote connections should implement secure transport protocols and proper credential management.
+- **Transport Security**: Remote connections should use HTTPS and the MCP
+  authorization model. Local stdio servers rely on process isolation, trusted
+  configuration, and secure handling of inherited credentials.
 
 #### Implementation Guidelines:
 
@@ -61,14 +69,24 @@ flowchart LR
 ```
 
 - **MCP Hosts**: Programs like VSCode, Claude Desktop, IDEs, or AI tools that want to access data through MCP
-- **MCP Clients**: Protocol clients that maintain 1:1 connections with servers
+- **MCP Clients**: Protocol components that maintain one logical relationship
+  with a server; MCP `2026-07-28` requests do not depend on one persistent
+  connection or session
 - **MCP Servers**: Lightweight programs that each expose specific capabilities through the standardized Model Context Protocol
 - **Local Data Sources**: Your computer's files, databases, and services that MCP servers can securely access
 - **Remote Services**: External systems available over the internet that MCP servers can connect to through APIs.
 
-The MCP Protocol is an evolving standard using date-based versioning (YYYY-MM-DD format). The current protocol version is **2025-11-25**. You can see the latest updates to the [protocol specification](https://modelcontextprotocol.io/specification/2025-11-25/)
+The MCP Protocol is an evolving standard using date-based versioning
+(YYYY-MM-DD format). The current protocol version is **2026-07-28**. See the
+[2026-07-28 protocol specification](https://modelcontextprotocol.io/specification/2026-07-28/).
 
-> **Looking ahead:** a release candidate for the next specification version, **2026-07-28**, was announced in May 2026 and is scheduled to ship July 28, 2026. It makes the protocol stateless at the transport layer (removing the `initialize` handshake and session IDs), formalizes an Extensions framework, and deprecates Roots, Sampling, and Logging in favor of newer patterns. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md) for a full breakdown.
+> **Current release:** MCP `2026-07-28` makes the protocol stateless at the
+> transport layer by removing the `initialize` handshake and protocol-level
+> session IDs. It also formalizes an Extensions framework and deprecates
+> Roots, Sampling, and Logging in favor of newer patterns. See
+> [What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md)
+> for a full breakdown and migration guidance. Examples that explicitly target
+> `2025-11-25` are retained as legacy compatibility lessons.
 
 ### 1. Hosts
 
@@ -81,7 +99,8 @@ In the Model Context Protocol (MCP), **Hosts** are AI applications that serve as
 **Hosts** are applications that coordinate AI model interactions. They:
 
 - **Orchestrate AI Models**: Execute or interact with LLMs to generate responses and coordinate AI workflows
-- **Manage Client Connections**: Create and maintain one MCP client per MCP server connection
+- **Manage Client Relationships**: Create and manage one MCP client for each MCP
+  server the host uses
 - **Control User Interface**: Handle conversation flow, user interactions, and response presentation  
 - **Enforce Security**: Control permissions, security constraints, and authentication
 - **Handle User Consent**: Manage user approval for data sharing and tool execution
@@ -89,12 +108,16 @@ In the Model Context Protocol (MCP), **Hosts** are AI applications that serve as
 
 ### 2. Clients
 
-**Clients** are essential components that maintain dedicated one-to-one connections between Hosts and MCP servers. Each MCP client is instantiated by the Host to connect to a specific MCP server, ensuring organized and secure communication channels. Multiple clients enable Hosts to connect to multiple servers simultaneously.
+**Clients** are protocol components created by a host for particular MCP
+servers. This is a logical one-to-one relationship, not a requirement for a
+persistent network connection. In MCP `2026-07-28`, each request is
+self-contained and may be handled by any server instance.
 
 **Clients** are connector components within the host application. They:
 
 - **Protocol Communication**: Send JSON-RPC 2.0 requests to servers with prompts and instructions
-- **Capability Negotiation**: Negotiate supported features and protocol versions with servers during initialization
+- **Capability Discovery**: Use `server/discover` to learn a server's supported
+  protocol versions, capabilities, and extensions
 - **Tool Execution**: Manage tool execution requests from models and process responses
 - **Real-time Updates**: Handle notifications and real-time updates from servers
 - **Response Processing**: Process and format server responses for display to users
@@ -108,7 +131,8 @@ In the Model Context Protocol (MCP), **Hosts** are AI applications that serve as
 - **Feature Registration**: Register and expose available primitives (resources, prompts, tools) to clients
 - **Request Processing**: Receive and execute tool calls, resource requests, and prompt requests from clients
 - **Context Provision**: Provide contextual information and data to enhance model responses
-- **State Management**: Maintain session state and handle stateful interactions when needed
+- **State Management**: Maintain application state with explicit handles passed
+  in requests when needed; MCP `2026-07-28` has no protocol-level sessions
 - **Real-time Notifications**: Send notifications about capability changes and updates to connected clients
 
 Servers can be developed by anyone to extend model capabilities with specialized functionality, and they support both local and remote deployment scenarios.
@@ -190,7 +214,11 @@ In the Model Context Protocol (MCP), **clients** can expose primitives that enab
 
 ### Sampling
 
-> **Deprecation notice:** the `2026-07-28` release candidate marks Sampling as deprecated in favor of direct integration with LLM provider APIs. It continues to work in `2025-11-25` and for at least a year after any deprecation, but new designs should prefer the replacement pattern. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md).
+> **Deprecated in MCP `2026-07-28`:** Sampling remains available for
+> compatibility, but new implementations should integrate directly with an LLM
+> provider API. It is eligible for removal in the first specification revision
+> released on or after July 28, 2027. See
+> [What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md).
 
 **Sampling** allows servers to request language model completions from the client's AI application. This primitive enables servers to access LLM capabilities without embedding their own model dependencies:
 
@@ -200,20 +228,29 @@ In the Model Context Protocol (MCP), **clients** can expose primitives that enab
 - **Dynamic Content Generation**: Allows servers to create contextual responses using the host's model
 - **Tool Calling Support**: Servers can include `tools` and `toolChoice` parameters to enable the client's model to invoke tools during sampling
 
-Sampling is initiated through the `sampling/complete` method, where servers send completion requests to clients.
+Sampling uses the `sampling/createMessage` method, where servers request a
+completion from clients.
 
 ### Roots
 
-> **Deprecation notice:** the `2026-07-28` release candidate marks Roots as deprecated in favor of tool parameters, resource URIs, or server configuration. It continues to work in `2025-11-25` and for at least a year after any deprecation. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md).
+> **Deprecated in MCP `2026-07-28`:** Roots remain available for
+> compatibility, but new implementations should pass directories or files via
+> tool parameters, resource URIs, or server configuration. Roots are eligible
+> for removal in the first specification revision released on or after July
+> 28, 2027. See
+> [What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md).
 
-**Roots** provide a standardized way for clients to expose filesystem boundaries to servers, helping servers understand which directories and files they have access to:
+**Roots** provide a standardized way for clients to identify filesystem
+locations that are relevant to servers:
 
-- **Filesystem Boundaries**: Define the boundaries of where servers can operate within the filesystem
-- **Access Control**: Help servers understand which directories and files they have permission to access
-- **Dynamic Updates**: Clients can notify servers when the list of roots changes
+- **Filesystem Hints**: Identify directories and files relevant to the request
+- **Separate Authorization**: Do not grant access or enforce a security boundary
+- **Per-request Capability**: Clients advertise Roots support in request metadata
 - **URI-Based Identification**: Roots use `file://` URIs to identify accessible directories and files
 
-Roots are discovered through the `roots/list` method, with clients sending `notifications/roots/list_changed` when roots change.
+In MCP `2026-07-28`, a server requests `roots/list` through an
+`InputRequiredResult` while processing a supported client request. The client
+returns the roots when it retries that original request.
 
 ### Elicitation  
 
@@ -224,13 +261,18 @@ Roots are discovered through the `roots/list` method, with clients sending `noti
 - **Interactive Workflows**: Enable servers to create step-by-step user interactions
 - **Dynamic Parameter Collection**: Gather missing or optional parameters during tool execution
 
-Elicitation requests are made using the `elicitation/request` method to collect user input through the client's interface.
+Elicitation uses the `elicitation/create` method inside an
+`InputRequiredResult` to collect user input through the client's interface.
 
 **URL Mode Elicitation**: Servers can also request URL-based user interactions, allowing servers to direct users to external web pages for authentication, confirmation, or data entry.
 
 ### Logging
 
-> **Deprecation notice:** the `2026-07-28` release candidate marks Logging as deprecated in favor of `stderr` for stdio transports and OpenTelemetry for structured observability. It continues to work in `2025-11-25` and for at least a year after any deprecation. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md).
+> **Deprecated in MCP `2026-07-28`:** Logging remains available for
+> compatibility, but new implementations should use `stderr` with stdio and
+> OpenTelemetry for structured observability. Logging is eligible for removal
+> in the first specification revision released on or after July 28, 2027. See
+> [What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md).
 
 **Logging** allows servers to send structured log messages to clients for debugging, monitoring, and operational visibility:
 
@@ -615,7 +657,9 @@ This JavaScript example demonstrates how to create an MCP server using the Model
 MCP includes several built-in concepts and mechanisms for managing security and authorization throughout the protocol:
 
 1. **Tool Permission Control**:  
-  Clients can specify which tools a model is allowed to use during a session. This ensures that only explicitly authorized tools are accessible, reducing the risk of unintended or unsafe operations. Permissions can be configured dynamically based on user preferences, organizational policies, or the context of the interaction.
+  Clients can specify which tools a model may use for each request or workflow.
+  This ensures that only explicitly authorized tools are accessible, reducing
+  the risk of unintended or unsafe operations.
 
 2. **Authentication**:  
   Servers can require authentication before granting access to tools, resources, or sensitive operations. This may involve API keys, OAuth tokens, or other authentication schemes. Proper authentication ensures that only trusted clients and users can invoke server-side capabilities.
@@ -624,7 +668,9 @@ MCP includes several built-in concepts and mechanisms for managing security and 
   Parameter validation is enforced for all tool invocations. Each tool defines the expected types, formats, and constraints for its parameters, and the server validates incoming requests accordingly. This prevents malformed or malicious input from reaching tool implementations and helps maintain the integrity of operations.
 
 4. **Rate Limiting**:  
-  To prevent abuse and ensure fair usage of server resources, MCP servers can implement rate limiting for tool calls and resource access. Rate limits can be applied per user, per session, or globally, and help protect against denial-of-service attacks or excessive resource consumption.
+  To prevent abuse and ensure fair usage of server resources, MCP servers can
+  implement rate limiting for tool calls and resource access. Rate limits can
+  be applied per user, credential, operation, or globally.
 
 By combining these mechanisms, MCP provides a secure foundation for integrating language models with external tools and data sources, while giving users and developers fine-grained control over access and usage.
 
@@ -632,12 +678,20 @@ By combining these mechanisms, MCP provides a secure foundation for integrating 
 
 MCP communication uses structured **JSON-RPC 2.0** messages to facilitate clear and reliable interactions between hosts, clients, and servers. The protocol defines specific message patterns for different types of operations:
 
-### Core Message Types:
+### Core Message Types
 
-#### **Initialization Messages**
-- **`initialize` Request**: Establishes connection and negotiates protocol version and capabilities
-- **`initialize` Response**: Confirms supported features and server information  
-- **`notifications/initialized`**: Signals that initialization is complete and the session is ready
+#### **Request Metadata and Discovery**
+
+- **Per-request metadata**: Every `2026-07-28` request is self-contained and
+  carries protocol version, client identity, and client capabilities in `_meta`.
+- **`server/discover` Request**: Retrieves supported protocol versions, server
+  identity, capabilities, and extensions when the client needs them.
+- **Streamable HTTP headers**: HTTP requests include `MCP-Protocol-Version` and
+  `Mcp-Method`; methods that address a named tool or resource also include
+  `Mcp-Name`.
+
+The `initialize`/`initialized` handshake and protocol-level session IDs belong
+to earlier protocol revisions and are not part of MCP `2026-07-28`.
 
 #### **Discovery Messages**
 - **`tools/list` Request**: Discovers available tools from the server
@@ -649,10 +703,15 @@ MCP communication uses structured **JSON-RPC 2.0** messages to facilitate clear 
 - **`resources/read` Request**: Retrieves content from a specific resource
 - **`prompts/get` Request**: Fetches a prompt template with optional parameters
 
-#### **Client-side Messages**
-- **`sampling/complete` Request**: Server requests LLM completion from the client
-- **`elicitation/request`**: Server requests user input through the client interface
-- **Logging Messages**: Server sends structured log messages to the client
+#### **Client-side Input Requests**
+
+- **`elicitation/create`**: Server requests user input through the client
+  interface while processing a client request.
+- **`sampling/createMessage`**: Deprecated server request for an LLM completion.
+- **`roots/list`**: Deprecated server request for client filesystem roots.
+
+Under `2026-07-28`, server-to-client input requests use the multi-round-trip
+`InputRequiredResult` pattern rather than relying on a persistent session.
 
 #### **Notification Messages**
 - **`notifications/tools/list_changed`**: Server notifies client of tool changes
@@ -668,11 +727,16 @@ All MCP messages follow JSON-RPC 2.0 format with:
 
 This structured communication ensures reliable, traceable, and extensible interactions supporting advanced scenarios like real-time updates, tool chaining, and robust error handling.
 
-### Tasks (Experimental)
+### Tasks Extension
 
-> **Looking ahead:** the `2026-07-28` release candidate graduates Tasks out of the experimental core specification into a dedicated Tasks extension with a redesigned lifecycle (`tasks/get`, `tasks/update`, `tasks/cancel`; `tasks/list` is removed). If you build against the experimental API described below, plan to migrate. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md).
+In MCP `2026-07-28`, Tasks is an official extension rather than an experimental
+core feature. It uses a redesigned `tasks/get`, `tasks/update`, and
+`tasks/cancel` lifecycle; `tasks/list` was removed. The experimental
+`2025-11-25` Tasks API is not backward compatible with this extension. See
+[What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md).
 
-**Tasks** are an experimental feature that provides durable execution wrappers enabling deferred result retrieval and status tracking for MCP requests:
+**Tasks** provide durable execution wrappers for deferred result retrieval and
+status tracking:
 
 - **Long-Running Operations**: Track expensive computations, workflow automation, and batch processing
 - **Deferred Results**: Poll for task status and retrieve results when operations complete
@@ -685,11 +749,15 @@ Tasks wrap standard MCP requests to enable asynchronous execution patterns for o
 
 - **Architecture**: MCP uses a client-server architecture where hosts manage multiple client connections to servers
 - **Participants**: The ecosystem includes hosts (AI applications), clients (protocol connectors), and servers (capability providers)
-- **Transport Mechanisms**: Communication supports STDIO (local) and Streamable HTTP with optional SSE (remote)
+- **Transport Mechanisms**: Communication supports stdio (local) and Streamable
+  HTTP (remote); `2026-07-28` removes the standalone GET event stream
 - **Core Primitives**: Servers expose tools (executable functions), resources (data sources), and prompts (templates)
-- **Client Primitives**: Servers can request sampling (LLM completions with tool calling support), elicitation (user input including URL mode), roots (filesystem boundaries), and logging from clients
-- **Experimental Features**: Tasks provide durable execution wrappers for long-running operations
-- **Protocol Foundation**: Built on JSON-RPC 2.0 with date-based versioning (current: 2025-11-25)
+- **Client Primitives**: Elicitation supports user input, while Sampling and
+  Roots are retained only as deprecated compatibility features
+- **Extensions**: The official Tasks extension provides durable execution
+  wrappers for long-running operations
+- **Protocol Foundation**: Built on JSON-RPC 2.0 with date-based versioning
+  (current: `2026-07-28`)
 - **Real-time Capabilities**: Supports notifications for dynamic updates and real-time synchronization
 - **Security First**: Explicit user consent, data privacy protection, and secure transport are core requirements
 
@@ -708,4 +776,5 @@ Design a simple MCP tool that would be useful in your domain. Define:
 
 Next: [Chapter 2: Security](../02-Security/README.md)
 
-Curious what's coming after `2025-11-25`? Read [What's Changing in MCP: The 2026-07-28 Release Candidate](./mcp-2026-07-28-release-candidate.md).
+Read [What's Changed in MCP: The 2026-07-28 Specification](./mcp-2026-07-28-release-candidate.md)
+for migration guidance from `2025-11-25`.

--- a/01-CoreConcepts/mcp-2026-07-28-release-candidate.md
+++ b/01-CoreConcepts/mcp-2026-07-28-release-candidate.md
@@ -1,10 +1,20 @@
-# What's Changing in MCP: The 2026-07-28 Release Candidate
+# What's Changed in MCP: The 2026-07-28 Specification
 
-> **Status:** Release Candidate. The `2026-07-28` specification is not final at the time of writing. It was announced May 21, 2026, and is scheduled to ship July 28, 2026. Everything in this lesson describes the release candidate; check the [draft specification](https://modelcontextprotocol.io/specification/draft) and its [changelog](https://modelcontextprotocol.io/specification/draft/changelog) for the latest status before you build against it. The rest of this curriculum is written against the current stable release, **MCP Specification 2025-11-25**, and will be updated once `2026-07-28` ships.
+> **Status:** Final. MCP Specification `2026-07-28` shipped on July 28, 2026
+> and is the current protocol revision. This lesson describes the final
+> specification. Some curriculum examples remain explicitly versioned to
+> `2025-11-25` because their SDKs have not yet adopted the new stateless API;
+> treat those examples as legacy compatibility guidance.
 
 ## Overview
 
-`2026-07-28` is the largest revision of MCP since it launched. Six Specification Enhancement Proposals (SEPs) remove protocol-level sessions and make MCP stateless at the transport layer, extensions become a first-class, versioned mechanism, and several features you've learned earlier in this curriculum (Roots, Sampling, Logging) are marked deprecated under a new lifecycle policy. This lesson summarizes what's changing, why it matters, and what it means for the code you've already written against `2025-11-25`.
+`2026-07-28` is the largest revision of MCP since it launched. Six
+Specification Enhancement Proposals (SEPs) remove protocol-level sessions and
+make MCP stateless at the transport layer, extensions become a first-class,
+versioned mechanism, and several features covered earlier in this curriculum
+(Roots, Sampling, Logging) are deprecated under a new lifecycle policy. This
+lesson summarizes what changed, why it matters, and what it means for code
+written against `2025-11-25`.
 
 Source: [The 2026-07-28 MCP Specification Release Candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) (Model Context Protocol Blog, David Soria Parra and Den Delimarsky).
 
@@ -16,7 +26,8 @@ By the end of this lesson, you will be able to:
 - Describe how the `initialize`/`initialized` handshake and `Mcp-Session-Id` header are replaced.
 - Identify the new `Mcp-Method` and `Mcp-Name` headers and the `ttlMs`/`cacheScope` caching metadata.
 - Recognize the Extensions framework and the two extensions shipping with this release: MCP Apps and Tasks.
-- List the six authorization SEPs that harden OAuth 2.0 / OIDC alignment.
+- Summarize the authorization hardening and Dynamic Client Registration
+  deprecation.
 - Identify which core features (Roots, Sampling, Logging) are now deprecated, and what that means in practice.
 - Explain the Full JSON Schema 2020-12 change for tool `inputSchema`/`outputSchema`.
 
@@ -50,7 +61,9 @@ Content-Type: application/json
 
 {"jsonrpc":"2.0","id":1,"method":"tools/call",
  "params":{"name":"search","arguments":{"q":"otters"},
-           "_meta":{"io.modelcontextprotocol/clientInfo":{"name":"my-app","version":"1.0"}}}}
+           "_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28",
+                    "io.modelcontextprotocol/clientInfo":{"name":"my-app","version":"1.0"},
+                    "io.modelcontextprotocol/clientCapabilities":{}}}}
 ```
 
 Any server instance can handle this request. Key changes:
@@ -84,7 +97,7 @@ A stateless protocol still needs a way for a server to ask the client for someth
 
   ```json
   {
-    "resultType": "inputRequired",
+    "resultType": "input_required",
     "inputRequests": {
       "confirm": {
         "type": "elicitation",
@@ -129,30 +142,44 @@ Tasks shipped as an experimental core feature in `2025-11-25`. Production use su
 
 ## Authorization Hardening
 
-Six SEPs harden the [authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization) to align more closely with real-world OAuth 2.0 / OpenID Connect deployments:
+Several SEPs harden the
+[authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+to align more closely with real-world OAuth 2.0 / OpenID Connect deployments:
 
 | SEP | Change |
 |---|---|
 | [SEP-2468](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468) | Clients must validate the `iss` parameter on authorization responses per [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207), mitigating mix-up attacks common in MCP's single-client, many-server pattern. A future version will require rejecting responses missing `iss`. |
-| [SEP-837](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837) | Clients declare their OpenID Connect `application_type` during Dynamic Client Registration, avoiding authorization servers defaulting a desktop/CLI client to `"web"` and rejecting its localhost redirect URI. |
-| [SEP-2352](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2352) | Clients bind registered credentials to the issuing authorization server's `issuer` and re-register when a resource migrates between authorization servers. |
+| [SEP-837](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837) | Compatibility-only Dynamic Client Registration clients declare their OpenID Connect `application_type`, avoiding incorrect `"web"` defaults for desktop and CLI clients. |
+| [SEP-2352](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2352) | Compatibility-only registered credentials are bound to the issuing authorization server's `issuer`; clients re-register if a resource migrates. |
 | [SEP-2207](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2207) | Documents how to request refresh tokens from OpenID Connect-style authorization servers. |
 | [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350) | Clarifies scope accumulation during step-up authorization. |
 | [SEP-2351](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2351) | Clarifies the `.well-known` discovery suffix. |
 
-If you're building an authorization server for MCP today, start supplying `iss` on authorization responses now — see [02-Security](../02-Security/README.md) for the current authorization guidance this will build on.
+If you're building an authorization server for MCP, supply `iss` on
+authorization responses and follow the final authorization specification. See
+[02-Security](../02-Security/README.md) for implementation guidance.
 
-## Roots, Sampling, and Logging Are Deprecated
+Dynamic Client Registration remains available for compatibility but is also
+deprecated in `2026-07-28`. New implementations should use Client ID Metadata
+Documents.
 
-Under the new [feature lifecycle policy](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)), three core client primitives you learned about in [Core Concepts](./README.md#roots) move to **Deprecated** status:
+## Deprecated Features
+
+Under the new
+[feature lifecycle policy](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577),
+Roots, Sampling, Logging, and Dynamic Client Registration are **Deprecated**:
 
 | Feature | Recommended replacement |
 |---|---|
 | Roots | Tool parameters, resource URIs, or server configuration |
 | Sampling | Direct integration with LLM provider APIs |
 | Logging | `stderr` for stdio transports; OpenTelemetry for structured observability |
+| Dynamic Client Registration | Client ID Metadata Documents |
 
-These are **annotation-only deprecations**: the methods, types, and capability flags keep working in this release and in every specification version published within a year of it. Removing any of them outright will require a separate SEP under the lifecycle policy — so nothing breaks in your existing [Sampling](../03-GettingStarted/14-sampling/README.md) samples today, but new servers should prefer the replacement patterns above.
+These features remain in `2026-07-28` for compatibility. They are eligible for
+removal in the first specification revision released on or after July 28, 2027;
+actual removal may happen later. New implementations should use the replacement
+patterns above.
 
 ## Full JSON Schema 2020-12 for Tools
 
@@ -175,28 +202,38 @@ This release contains breaking changes, which the MCP maintainers don't intend t
 ## Release Timeline and Validation
 
 - The release candidate was locked May 21, 2026.
-- The final specification is scheduled for July 28, 2026.
-- The ten-week window between the two lets SDK maintainers and client implementers validate the changes against real workloads; Tier 1 SDKs are expected to ship support within this window under the [SDK tier system](https://modelcontextprotocol.io/docs/sdk).
-- Track the full set of changes in the [draft specification](https://modelcontextprotocol.io/specification/draft) and its [changelog](https://modelcontextprotocol.io/specification/draft/changelog).
+- The final specification shipped July 28, 2026.
+- SDK support may lag the specification. Check the
+  [SDK documentation](https://modelcontextprotocol.io/docs/sdk) and the SDK's
+  release notes before migrating an example.
+- Track the final changes in the
+  [2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28/)
+  and its
+  [changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog).
 
 ## What This Means for This Curriculum
 
-Everything you've learned so far in this course targets **2025-11-25**, which remains the current stable specification until `2026-07-28` ships. Concretely:
+The curriculum is transitioning from `2025-11-25` examples to the current
+`2026-07-28` specification. Concretely:
 
-- **Sessions and the `initialize` handshake** (covered in [Core Concepts](./README.md) and [Lesson 6: HTTP Streaming](../03-GettingStarted/06-http-streaming/README.md)) still work as documented today, but expect them to be replaced by the stateless request model above once you upgrade to `2026-07-28`-compatible SDKs.
-- **Sampling and Roots** (also covered in [Core Concepts](./README.md)) remain fully functional but are deprecated — new designs should prefer the replacement patterns listed above.
+- **Sessions and the `initialize` handshake** in examples explicitly targeting
+  `2025-11-25` are legacy behavior. The `2026-07-28` protocol replaces them
+  with the stateless request model above.
+- **Sampling and Roots** remain available for compatibility but are deprecated.
+  New designs should use the replacement patterns listed above.
 - **The experimental Tasks feature**, if you've used it, will need migrating to the Tasks extension's new lifecycle.
 - **MCP Apps** ([Lesson 15](../03-GettingStarted/15-mcp-apps/README.md)) is unaffected in practice; it simply moves under the formal Extensions framework.
 
 ## Additional Resources
 
-- [The 2026-07-28 MCP Specification Release Candidate (blog post)](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+- [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
+- [2026-07-28 Changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [The 2026-07-28 MCP Specification Release Candidate (historical blog post)](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
 - [The Future of MCP Transports](https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/)
-- [MCP Draft Specification](https://modelcontextprotocol.io/specification/draft)
-- [MCP Draft Changelog](https://modelcontextprotocol.io/specification/draft/changelog)
 - [SEP Guidelines](https://modelcontextprotocol.io/community/sep-guidelines)
 - [MCP SDK Tier System](https://modelcontextprotocol.io/docs/sdk)
 
 ## Next Steps
 
-Head back to [Core Concepts](./README.md) or continue to [Security](../02-Security/README.md) to see how today's `2025-11-25` guidance maps onto what's coming.
+Head back to [Core Concepts](./README.md) or continue to
+[Security](../02-Security/README.md) to apply the current `2026-07-28` guidance.

--- a/02-Security/README.md
+++ b/02-Security/README.md
@@ -28,9 +28,19 @@ Research from the [Microsoft Digital Defense Report](https://aka.ms/mddr) demons
 
 ## Current Security Landscape
 
-> **Note:** This information reflects MCP security standards as of **February 5, 2026**, aligned with **MCP Specification 2025-11-25**. The MCP protocol continues evolving rapidly, and future implementations may introduce new authentication patterns and enhanced controls. Always refer to the current [MCP Specification](https://spec.modelcontextprotocol.io/), [MCP GitHub repository](https://github.com/modelcontextprotocol), and [security best practices documentation](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices) for the latest guidance.
+> **Note:** This chapter combines established MCP security controls with the
+> current **MCP Specification 2026-07-28** authorization guidance. Always refer
+> to the current [MCP Specification](https://modelcontextprotocol.io/specification/2026-07-28/),
+> [MCP GitHub repository](https://github.com/modelcontextprotocol), and
+> [security best practices documentation](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)
+> when implementing security-sensitive code.
 
-> **Looking ahead:** the `2026-07-28` release candidate hardens authorization further — clients must validate the `iss` parameter on authorization responses (RFC 9207), declare an OpenID Connect `application_type` during Dynamic Client Registration, and bind registered credentials to the issuing authorization server. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../01-CoreConcepts/mcp-2026-07-28-release-candidate.md) for the full list of authorization SEPs.
+> **Authorization update:** MCP `2026-07-28` requires clients to validate the
+> `iss` parameter on authorization responses (RFC 9207) and bind registered
+> credentials to the issuing authorization server. Dynamic Client Registration
+> is deprecated; new implementations should use Client ID Metadata Documents.
+> See [What's Changed in MCP: The 2026-07-28 Specification](../01-CoreConcepts/mcp-2026-07-28-release-candidate.md)
+> for the full list of authorization changes.
 
 ## 🏔️ MCP Security Summit Workshop (Sherpa)
 
@@ -81,7 +91,9 @@ The [OWASP MCP Azure Security Guide](https://microsoft.github.io/mcp-azure-secur
 The MCP specification has evolved significantly in its approach to authentication and authorization:
 
 - **Original Approach**: Early specifications required developers to implement custom authentication servers, with MCP servers acting as OAuth 2.0 Authorization Servers managing user authentication directly
-- **Current Standard (2025-11-25)**: Updated specification allows MCP servers to delegate authentication to external identity providers (such as Microsoft Entra ID), improving security posture and reducing implementation complexity
+- **Current Standard (`2026-07-28`)**: MCP servers can delegate authentication
+  to external identity providers such as Microsoft Entra ID. Clients must also
+  apply the current issuer-validation and credential-binding requirements.
 - **Transport Layer Security**: Enhanced support for secure transport mechanisms with proper authentication patterns for both local (STDIO) and remote (Streamable HTTP) connections
 
 ## Authentication & Authorization Security
@@ -445,9 +457,9 @@ These foundational practices create a robust security baseline that enhances the
 ## Comprehensive Resources
 
 ### **Official MCP Security Documentation**
-- [MCP Specification (Current: 2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
-- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices)
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [MCP Specification (Current: 2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 - [MCP GitHub Repository](https://github.com/modelcontextprotocol)
 
 ### **OWASP MCP Security Resources**

--- a/03-GettingStarted/01-first-server/README.md
+++ b/03-GettingStarted/01-first-server/README.md
@@ -1,5 +1,10 @@
 # Getting Started with MCP
 
+> [!NOTE]
+> The Java HTTP example in this lesson uses the legacy HTTP+SSE transport and
+> targets an SDK compatible with MCP `2025-11-25`. For new remote servers, use
+> the `2026-07-28` Streamable HTTP transport and verify support in your SDK.
+
 Welcome to your first steps with the Model Context Protocol (MCP)! Whether you're new to MCP or looking to deepen your understanding, this guide will walk you through the essential setup and development process. You'll discover how MCP enables seamless integration between AI models and applications, and learn how to quickly get your environment ready for building and testing MCP-powered solutions.
 
 > TLDR; If you build AI apps, you know that you can add tools and other resources to your LLM (large language model), to make the LLM more knowledgeable. However if you place those tools and resources on a server, the app and the server capabilities can be used by any client with/without an LLM.

--- a/03-GettingStarted/01-first-server/solution/java/README.md
+++ b/03-GettingStarted/01-first-server/solution/java/README.md
@@ -1,5 +1,10 @@
 # Basic Calculator MCP Service
 
+> [!NOTE]
+> This Java solution uses the legacy HTTP+SSE transport and targets an SDK
+> compatible with MCP `2025-11-25`. It is retained for matching course code;
+> new remote servers should use `2026-07-28` Streamable HTTP support.
+
 This service provides basic calculator operations through the Model Context Protocol (MCP) using Spring Boot with WebFlux transport. It's designed as a simple example for beginners learning about MCP implementations.
 
 For more information, see the [MCP Server Boot Starter](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) reference documentation.

--- a/03-GettingStarted/03-llm-client/README.md
+++ b/03-GettingStarted/03-llm-client/README.md
@@ -1,5 +1,10 @@
 # Creating a client with LLM
 
+> [!NOTE]
+> The Java client examples connect through the legacy HTTP+SSE transport and
+> target MCP `2025-11-25` SDK APIs. Use a `2026-07-28`-compatible SDK and
+> Streamable HTTP for new remote clients.
+
 So far, you've seen how to create a server and a client. The client has been able to call the server explicitly to list its tools, resources, and prompts. However, this is not a very practical approach. Your users live in the agentic era and expect to use prompts and communicate with an LLM instead. They do not care whether you use MCP to store your capabilities; they simply expect to interact using natural language. So how do we solve this? The solution is to add an LLM to the client.
 
 ## Overview

--- a/03-GettingStarted/03-llm-client/solution/java/README.md
+++ b/03-GettingStarted/03-llm-client/solution/java/README.md
@@ -1,5 +1,10 @@
 # Calculator LLM Client
 
+> [!NOTE]
+> This solution connects to the course's legacy HTTP+SSE calculator service and
+> targets MCP `2025-11-25` SDK APIs. It is not a `2026-07-28` Streamable HTTP
+> example.
+
 A Java application that demonstrates how to use LangChain4j to connect to an MCP (Model Context Protocol) calculator service through the MiniMax OpenAI-compatible API.
 
 ## Prerequisites

--- a/03-GettingStarted/05-stdio-server/README.md
+++ b/03-GettingStarted/05-stdio-server/README.md
@@ -24,7 +24,8 @@ By the end of this lesson, you will be able to:
 
 ## stdio Transport - How it Works
 
-The stdio transport is one of two supported transport types in the current MCP specification (2025-11-25). Here's how it works:
+The stdio transport is one of the two standard transports in MCP Specification
+`2026-07-28`. Here's how it works:
 
 - **Simple Communication**: The server reads JSON-RPC messages from standard input (`stdin`) and sends messages to standard output (`stdout`).
 - **Process-based**: The client launches the MCP server as a subprocess.
@@ -589,6 +590,6 @@ Now that you've learned how to build MCP servers with the stdio transport, you c
 
 ## Additional Resources
 
-- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) - Official specification
+- [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/) - Current specification
 - [MCP SDK Documentation](https://github.com/modelcontextprotocol/sdk) - SDK references for all languages
 - [Community Examples](../../06-CommunityContributions/README.md) - More server examples from the community

--- a/03-GettingStarted/06-http-streaming/README.md
+++ b/03-GettingStarted/06-http-streaming/README.md
@@ -2,7 +2,15 @@
 
 This chapter provides a comprehensive guide to implementing secure, scalable, and real-time streaming with the Model Context Protocol (MCP) using HTTPS. It covers the motivation for streaming, the available transport mechanisms, how to implement streamable HTTP in MCP, security best practices, migration from SSE, and practical guidance for building your own streaming MCP applications. 
 
-> **Looking ahead:** this lesson describes Streamable HTTP under **MCP Specification 2025-11-25**, where a session is established during `initialize` and pinned with an `Mcp-Session-Id` header. The `2026-07-28` release candidate removes the handshake and session ID entirely, making every request self-contained and routable to any server instance without sticky sessions. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md) for details.
+> [!WARNING]
+> The implementation examples in this lesson target **MCP Specification
+> `2025-11-25`** and demonstrate the legacy `initialize` handshake,
+> `Mcp-Session-Id`, GET event stream, and resumability model. MCP `2026-07-28`
+> removes those features. Current Streamable HTTP requests are self-contained
+> POST requests with `MCP-Protocol-Version` and `Mcp-Method` headers, plus
+> `Mcp-Name` where required. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md)
+> before using these examples in a new implementation.
 
 ## Transport Mechanisms and Streaming in MCP
 
@@ -13,22 +21,24 @@ This section explores the different transport mechanisms available in MCP and th
 A transport mechanism defines how data is exchanged between the client and server. MCP supports multiple transport types to suit different environments and requirements:
 
 - **stdio**: Standard input/output, suitable for local and CLI-based tools. Simple but not suitable for web or cloud.
-- **SSE (Server-Sent Events)**: Allows servers to push real-time updates to clients over HTTP. Good for web UIs, but limited in scalability and flexibility. As of MCP Specification 2025-06-18, the standalone SSE (Server-Sent Events) transport has been deprecated and replaced by "Streamable HTTP" transport.
+- **HTTP+SSE**: The legacy remote transport, deprecated in MCP `2025-03-26`
+    and replaced by Streamable HTTP. Do not use it for new implementations.
 - **Streamable HTTP**: Modern HTTP-based streaming transport, supporting notifications and better scalability. Recommended for most production and cloud scenarios.
 
 ### Comparison Table
 
 Have a look at the comparison table below to understand the differences between these transport mechanisms:
 
-| Transport         | Real-time Updates | Streaming | Scalability | Use Case                |
-|-------------------|------------------|-----------|-------------|-------------------------|
-| stdio             | No               | No        | Low         | Local CLI tools         |
-| SSE               | Yes              | Yes       | Medium      | Web, real-time updates  |
-| Streamable HTTP   | Yes              | Yes       | High        | Cloud, multi-client     |
+| Transport | Status | Notifications | Typical use |
+|---|---|---|---|
+| stdio | Current | Yes | Local subprocesses |
+| HTTP+SSE | Deprecated | Yes | Legacy remote implementations |
+| Streamable HTTP | Current | Yes | Remote and cloud servers |
 
 > **Tip:** Choosing the right transport impacts performance, scalability, and user experience. **Streamable HTTP** is recommended for modern, scalable, and cloud-ready applications.
 
-Note the transports stdio and SSE that you were shown in the previous chapters and how streamable HTTP is the transport covered in this chapter.
+The standard transports are stdio and Streamable HTTP. HTTP+SSE appears in
+older examples only.
 
 ## Streaming: Concepts and Motivation
 
@@ -233,9 +243,13 @@ The main result is still sent as a single response. However, notifications can b
 
 We said "Notification", what does that mean in the context of MCP?
 
-A notification is a message sent from the server to the client to inform about progress, status, or other events during a long-running operation. Notifications improve transparency and user experience.
+A notification is a JSON-RPC message that does not have an `id` and does not
+receive a response. MCP uses notifications for progress, cancellation, and
+other one-way events.
 
-For example, a client is supposed to send a notification once the initial handshake with the server has been made.
+In MCP `2025-11-25`, a client sends `notifications/initialized` after the
+initialization handshake. MCP `2026-07-28` has no initialization handshake, so
+this notification is legacy behavior.
 
 A notification looks like so as a JSON message:
 
@@ -249,11 +263,16 @@ A notification looks like so as a JSON message:
 }
 ```
 
-Notifications belongs to a topic in MCP referred to as ["Logging"](https://modelcontextprotocol.io/specification/draft/server/utilities/logging).
+Logging is one feature that uses notifications; notifications themselves are a
+general JSON-RPC message type.
 
-> **Deprecation notice:** the `2026-07-28` MCP specification release candidate marks the Logging primitive as deprecated in favor of `stderr` for stdio transports and OpenTelemetry for structured observability. Logging continues to work in `2025-11-25` and for at least a year after any formal deprecation. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> **Deprecated in MCP `2026-07-28`:** the Logging feature remains available
+> for compatibility but is eligible for removal in the first specification
+> revision released on or after July 28, 2027. New implementations should use
+> `stderr` with stdio or OpenTelemetry for structured observability.
 
-To get logging to work, the server needs to enable it as feature/capability like so:
+For a legacy `2025-11-25` implementation, the server enables the Logging
+capability as follows:
 
 ```json
 {

--- a/03-GettingStarted/09-deployment/README.md
+++ b/03-GettingStarted/09-deployment/README.md
@@ -1,5 +1,10 @@
 # Deploying MCP Servers
 
+> [!NOTE]
+> Configuration examples that use a `/sse` endpoint target the legacy HTTP+SSE
+> transport. MCP `2026-07-28` remote servers use Streamable HTTP, normally at a
+> server-defined endpoint such as `/mcp`.
+
 Deploying your MCP server allows others to access its tools and resources beyond your local environment. There are several deployment strategies to consider, depending on your requirements for scalability, reliability, and ease of management. Below you'll find guidance for deploying MCP servers locally, in containers, and to the cloud.
 
 ## Overview

--- a/03-GettingStarted/10-advanced/README.md
+++ b/03-GettingStarted/10-advanced/README.md
@@ -3,7 +3,9 @@
 There are two different types of servers exposed in the MCP SDK, your normal server and the low-level server. Normally, you would use the regular server to add features to it. For some cases though, you want to rely on the low-level server such as:
 
 - Better architecture. It's possible to create a clean architecture with both the regular server and a low-level server but it can be argued that it's slightly easier with a low-level server.
-- Feature availability. Some advanced features can only be used with a low-level server. You will see this in later chapters as we add sampling (deprecated in `2026-07-28` release candidate) and elicitation.
+- Feature availability. Some advanced features can only be used with a
+    low-level server. Later chapters cover Elicitation and the legacy Sampling
+    feature, which is deprecated in MCP `2026-07-28`.
 
 ## Regular server vs low-level server
 

--- a/03-GettingStarted/11-simple-auth/README.md
+++ b/03-GettingStarted/11-simple-auth/README.md
@@ -142,7 +142,12 @@ Client
 
 ### -1- Create a web server and MCP instance
 
-> **Looking ahead:** the TypeScript example below tracks HTTP transports in a `transports` map keyed by `mcp-session-id`, per **MCP Specification 2025-11-25**. The `2026-07-28` release candidate removes the `initialize` handshake and session ID entirely, so this per-session transport map goes away in favor of stateless, self-contained requests. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> [!WARNING]
+> The TypeScript example below targets MCP `2025-11-25`. It tracks transports
+> by `mcp-session-id` and is not a current `2026-07-28` transport example. MCP
+> `2026-07-28` removes the `initialize` handshake and protocol session ID; new
+> implementations use self-contained requests. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
 In our first step, we need to create the web server instance and the MCP Server.
 

--- a/03-GettingStarted/12-mcp-hosts/README.md
+++ b/03-GettingStarted/12-mcp-hosts/README.md
@@ -1,5 +1,10 @@
 # Setting Up Popular MCP Host Clients
 
+> [!NOTE]
+> Host configurations that point to `/sse` are legacy HTTP+SSE examples for
+> MCP `2025-11-25`. For MCP `2026-07-28`, select Streamable HTTP in hosts that
+> support it and use the endpoint configured by the server.
+
 This guide covers how to configure and use MCP servers with popular AI host applications. Each host has its own configuration approach, but once set up, they all communicate with MCP servers using the standardized protocol.
 
 ## What is an MCP Host?
@@ -384,5 +389,5 @@ Different hosts support different transport mechanisms:
 
 - [Claude Desktop MCP Documentation](https://docs.anthropic.com/en/docs/claude-desktop/mcp)
 - [VS Code MCP Extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-mcp)
-- [MCP Specification - Transports](https://spec.modelcontextprotocol.io/specification/2025-11-25/basic/transports/)
+- [MCP Specification - Transports](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/)
 - [Official MCP Servers Registry](https://github.com/modelcontextprotocol/servers)

--- a/03-GettingStarted/13-mcp-inspector/README.md
+++ b/03-GettingStarted/13-mcp-inspector/README.md
@@ -1,5 +1,10 @@
 # Debugging with MCP Inspector
 
+> [!NOTE]
+> Commands using `--sse` and URLs ending in `/sse` test the legacy HTTP+SSE
+> transport. For a new MCP `2026-07-28` server, use an Inspector version that
+> supports Streamable HTTP and select that transport instead.
+
 The **MCP Inspector** is an essential debugging tool that lets you interactively test and troubleshoot your MCP servers without needing a full AI host application. Think of it as "Postman for MCP" - it provides a visual interface to send requests, view responses, and understand how your server behaves.
 
 ## Why Use MCP Inspector?
@@ -225,7 +230,10 @@ Content-Type: application/json
 
 ## Message Log Analysis
 
-The message log shows all MCP protocol messages:
+The message log shows all MCP protocol messages. The transcript below is from a
+legacy `2025-11-25` server and includes the removed `initialize` handshake. A
+`2026-07-28` server uses self-contained request metadata and `server/discover`
+instead.
 
 ```
 14:32:01 → {"jsonrpc":"2.0","id":1,"method":"initialize",...}
@@ -430,5 +438,5 @@ You've completed Module 3: Getting Started! Continue your learning:
 ## Additional Resources
 
 - [MCP Inspector GitHub Repository](https://github.com/modelcontextprotocol/inspector)
-- [MCP Specification - Protocol Messages](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification - Protocol Messages](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)

--- a/03-GettingStarted/14-sampling/README.md
+++ b/03-GettingStarted/14-sampling/README.md
@@ -1,10 +1,18 @@
-> [DEPRECATED: 2026-07-28 RELEASE CANDIDATE](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)
+> [!WARNING]
+> Sampling is deprecated in MCP `2026-07-28`. This lesson is retained for
+> legacy implementations. New servers should integrate directly with an LLM
+> provider API.
 
 # Sampling - delegate features to the Client
 
-> **Deprecation notice:** the `2026-07-28` MCP specification release candidate marks Sampling as deprecated in favor of direct integration with LLM provider APIs. Sampling continues to work in `2025-11-25` and for at least a year after any formal deprecation, so everything in this lesson remains valid — but new server designs should evaluate the replacement pattern. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> Sampling remains in the `2026-07-28` specification for compatibility and is
+> eligible for removal in the first revision released on or after July 28,
+> 2027. Examples in this lesson may use SDK APIs that implement `2025-11-25`.
+> See [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
-Sometimes, you need the MCP Client and the MCP Server to collaborate to achieve a common goal. You might have a case where the Server requires the help of an LLM that sits on the client. For this situation, sampling is what you should use.
+In legacy implementations, Sampling lets an MCP server request help from an LLM
+managed by the client. For new implementations, call the chosen LLM provider
+directly instead.
 
 Let's explore some use cases and how to build a solution involving sampling.
 
@@ -140,7 +148,8 @@ Sampling messages aren't constrained to just text but you can also send, images 
 }
 ```
 
-> NOTE: for more detailed info on Sampling, check out the [official docs](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling)
+> NOTE: For current status and migration guidance, see the
+> [deprecated Sampling documentation](https://modelcontextprotocol.io/specification/2026-07-28/client/sampling).
 
 ## How to Configure Sampling in the Client
 

--- a/03-GettingStarted/14-sampling/code/python/README.md
+++ b/03-GettingStarted/14-sampling/code/python/README.md
@@ -1,5 +1,10 @@
 # Run the sample
 
+> [!WARNING]
+> This sample uses deprecated Sampling and a legacy HTTP+SSE endpoint. It is
+> retained for MCP `2025-11-25` compatibility. New implementations should call
+> an LLM provider directly and use Streamable HTTP for remote MCP traffic.
+
 ## Create virtual environment
 
 ```sh

--- a/03-GettingStarted/README.md
+++ b/03-GettingStarted/README.md
@@ -16,7 +16,10 @@ This section consists of several lessons:
 
 - **5 stdio Transport Server** stdio transport is the recommended standard for local MCP server-to-client communication, providing secure subprocess-based communication with built-in process isolation [to the lesson](05-stdio-server/README.md)
 
-- **6 HTTP Streaming with MCP (Streamable HTTP)**. Learn about modern HTTP streaming transport (the recommended approach for remote MCP servers per [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/basic/transports/#streamable-http)), progress notifications, and how to implement scalable, real-time MCP servers and clients using Streamable HTTP. [to the lesson](06-http-streaming/README.md)
+- **6 HTTP Streaming with MCP (Streamable HTTP)**. Learn about the standard
+	remote transport in [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http),
+	plus the legacy session-based implementation retained in the lesson.
+	[to the lesson](06-http-streaming/README.md)
 
 - **7 Utilising AI Toolkit for VSCode** to consume and test your MCP Clients and Servers [to the lesson](07-aitk/README.md)
 
@@ -32,7 +35,9 @@ This section consists of several lessons:
 
 - **13 MCP Inspector**. Debug and test your MCP servers interactively using the MCP Inspector tool. Learn to troubleshoot tools, resources, and protocol messages, [to the lesson](./13-mcp-inspector/README.md)
 
-- **14 Sampling**. Create MCP Servers that collaborate with MCP clients on LLM related tasks (deprecated in `2026-07-28` release candidate; still valid for `2025-11-25`). [to the lesson](./14-sampling/README.md)
+- **14 Sampling**. Learn the legacy Sampling primitive for `2025-11-25` and
+	how to migrate new designs to direct LLM provider integration. Sampling is
+	deprecated in MCP `2026-07-28`. [to the lesson](./14-sampling/README.md)
 
 - **15 MCP Apps**. Build MCP Servers that also reply with UI instructions, [to the lesson](./15-mcp-apps/README.md)
 
@@ -65,9 +70,13 @@ Before diving into MCP development, ensure you have:
 
 ### Official SDKs
 
-In the upcoming chapters you will see solutions built using Python, TypeScript, Java and .NET. Here are all the officially supported SDKs.
+In the upcoming chapters you will see solutions built using Python, TypeScript,
+Java and .NET. Here are the official SDKs.
 
-MCP provides official SDKs for multiple languages (aligned with [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/)):
+SDK support for MCP `2026-07-28` is rolling out independently by language.
+Before running an example, check its package version and the SDK's release notes
+for supported protocol revisions. See the
+[official SDK list](https://modelcontextprotocol.io/docs/sdk):
 - [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk) - Maintained in collaboration with Microsoft
 - [Java SDK](https://github.com/modelcontextprotocol/java-sdk) - Maintained in collaboration with Spring AI
 - [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) - The official TypeScript implementation

--- a/03-GettingStarted/samples/java/calculator/README.md
+++ b/03-GettingStarted/samples/java/calculator/README.md
@@ -1,5 +1,10 @@
 # Basic Calculator MCP Service
 
+> [!NOTE]
+> This sample uses the legacy HTTP+SSE transport and targets an SDK compatible
+> with MCP `2025-11-25`. New remote servers should use `2026-07-28` Streamable
+> HTTP support.
+
 This service provides basic calculator operations through the Model Context Protocol (MCP) using Spring Boot with WebFlux transport. It's designed as a simple example for beginners learning about MCP implementations.
 
 For more information, see the [MCP Server Boot Starter](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) reference documentation.

--- a/04-PracticalImplementation/README.md
+++ b/04-PracticalImplementation/README.md
@@ -26,7 +26,10 @@ By the end of this lesson, you will be able to:
 
 ## Official SDK Resources
 
-The Model Context Protocol offers official SDKs for multiple languages (aligned with [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/)):
+The Model Context Protocol offers official SDKs for multiple languages. SDK
+support for MCP `2026-07-28` rolls out independently, so check each SDK's
+release notes and the example's package version before assuming protocol
+compatibility. See the [official SDK list](https://modelcontextprotocol.io/docs/sdk):
 
 - [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk)
 - [Java with Spring SDK](https://github.com/modelcontextprotocol/java-sdk) **Note:** requires dependency on [Project Reactor](https://projectreactor.io). (See [discussion issue 246](https://github.com/orgs/modelcontextprotocol/discussions/246).)
@@ -177,7 +180,8 @@ Let's have a look at the authorization flow more in detail:
 
 #### MCP authorization specification
 
-Learn more about the [MCP Authorization specification](https://spec.modelcontextprotocol.io/specification/2025-11-25/basic/authorization/)
+Learn more about the
+[MCP Authorization specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/).
 
 ## Deploy Remote MCP Server to Azure
 

--- a/04-PracticalImplementation/pagination/README.md
+++ b/04-PracticalImplementation/pagination/README.md
@@ -457,6 +457,6 @@ async def list_tools(cursor: str | None = None) -> ListToolsResult:
 
 ## Additional Resources
 
-- [MCP Specification - Pagination](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification - Pagination](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [Cursor-Based Pagination Explained](https://slack.engineering/evolving-api-pagination-at-slack/)
 - [Python SDK pagination tests](https://github.com/modelcontextprotocol/python-sdk/blob/main/tests/client/test_list_methods_cursor.py)

--- a/05-AdvancedTopics/README.md
+++ b/05-AdvancedTopics/README.md
@@ -10,7 +10,12 @@ This chapter covers a series of advanced topics in Model Context Protocol (MCP) 
 
 This lesson explores advanced concepts in Model Context Protocol implementation, focusing on multi-modal integration, scalability, security best practices, and enterprise integration. These topics are essential for building production-grade MCP applications that can handle complex requirements in enterprise environments.
 
-> **Looking ahead:** several topics below are affected by the `2026-07-28` MCP specification release candidate — Root Contexts (5.4) and Sampling (5.6) build on primitives that the release candidate marks as deprecated, and the experimental Tasks feature referenced in Protocol Features (5.16) moves to a dedicated Tasks extension. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../01-CoreConcepts/mcp-2026-07-28-release-candidate.md) for details.
+> **Current specification note:** MCP `2026-07-28` deprecates the Roots and
+> Sampling primitives covered in lessons 5.4 and 5.6. It also moves the
+> experimental Tasks feature referenced in Protocol Features (5.16) to a
+> dedicated Tasks extension. Those lessons are retained for legacy
+> `2025-11-25` implementations and include migration guidance. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
 ## Learning Objectives
 
@@ -29,9 +34,9 @@ By the end of this lesson, you will be able to:
 | [5.1 Integration with Azure](./mcp-integration/README.md) | Integrate with Azure | Learn how to integrate your MCP Server on Azure |
 | [5.2 Multi modal sample](./mcp-multi-modality/README.md) | MCP Multi modal samples  | Samples for audio, image and multi modal response |
 | [5.3 MCP OAuth2 sample](./mcp-oauth2-demo/) | MCP OAuth2 Demo | Minimal Spring Boot app showing OAuth2 with MCP, both as Authorization and Resource Server. Demonstrates secure token issuance, protected endpoints, Azure Container Apps deployment, and API Management integration. |
-| [5.4 Root Contexts](./mcp-root-contexts/README.md) | Root contexts  | Learn more about root context and how to implement them (deprecated in `2026-07-28` release candidate; still valid for `2025-11-25`) |
+| [5.4 Root Contexts](./mcp-root-contexts/README.md) | Root contexts  | Learn the legacy `2025-11-25` Roots primitive and current migration options (deprecated in `2026-07-28`) |
 | [5.5 Routing](./mcp-routing/README.md) | Routing | Learn different types of routing |
-| [5.6 Sampling](./mcp-sampling/README.md) | Sampling | Learn how to work with sampling (deprecated in `2026-07-28` release candidate; still valid for `2025-11-25`) |
+| [5.6 Sampling](./mcp-sampling/README.md) | Sampling | Learn the legacy `2025-11-25` Sampling primitive and current migration options (deprecated in `2026-07-28`) |
 | [5.7 Scaling](./mcp-scaling/README.md) | Scaling  | Learn about scaling |
 | [5.8 Security](./mcp-security/README.md) | Security  | Secure your MCP Server |
 | [5.9 Web Search sample](./web-search-mcp/README.md) | Web Search MCP | Python MCP server and client integrating with SerpAPI for real-time web, news, product search, and Q&A. Demonstrates multi-tool orchestration, external API integration, and robust error handling. |
@@ -44,13 +49,17 @@ By the end of this lesson, you will be able to:
 | [5.16 Protocol Features Deep Dive](./mcp-protocol-features/README.md) | Protocol Features | Master advanced protocol features including progress notifications, request cancellation, resource templates, and error handling patterns.|
 | [5.17 Adversarial Multi-Agent Reasoning](./mcp-adversarial-agents/README.md) | Adversarial Agents | Use two agents with opposing positions, sharing a single MCP tool set, to catch hallucinations, surface edge cases, and produce better-calibrated outputs through structured debate.|
 
-> **New in MCP Specification 2025-11-25**: The specification now includes experimental support for **Tasks** (long-running operations with progress tracking), **Tool Annotations** (metadata about tool behavior for safety), **URL Mode Elicitation** (requesting specific URL content from clients), and enhanced **Roots** (for workspace context management). See the [MCP Specification changelog](https://spec.modelcontextprotocol.io/) for full details.
+> **Historical `2025-11-25` note:** that revision introduced experimental
+> Tasks and expanded several protocol features. In `2026-07-28`, Tasks moved to
+> an official extension and Roots became deprecated. Do not use the
+> `2025-11-25` feature status as current guidance; see the
+> [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog).
 
 ## Additional References
 
 For the most up-to-date information on advanced MCP topics, refer to:
 - [MCP Documentation](https://modelcontextprotocol.io/)
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [GitHub Repository](https://github.com/modelcontextprotocol)
 - [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/mcp/) - Security risks and mitigations
 - [MCP Security Summit Workshop (Sherpa)](https://azure-samples.github.io/sherpa/) - Hands-on security training

--- a/05-AdvancedTopics/mcp-protocol-features/README.md
+++ b/05-AdvancedTopics/mcp-protocol-features/README.md
@@ -2,15 +2,20 @@
 
 This guide explores advanced MCP protocol features that go beyond basic tool and resource handling. Understanding these features helps you build more robust, user-friendly, and production-ready MCP servers.
 
-> **Looking ahead:** the `2026-07-28` release candidate deprecates the Logging primitive (favoring `stderr` for stdio and OpenTelemetry for structured observability), removes the `initialize`/session model referenced in Server Lifecycle Events below, and moves the experimental Tasks feature into a dedicated Tasks extension with a new `tasks/get`/`tasks/update`/`tasks/cancel` lifecycle. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> **MCP `2026-07-28` scope:** server process startup and shutdown remain
+> application concerns, but the MCP `initialize` handshake and protocol-level
+> sessions are removed. The Logging section below is retained for legacy
+> implementations; new servers should use `stderr` or OpenTelemetry. Tasks is
+> now a separately versioned extension. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
 ## Features Covered
 
 1. **Progress Notifications** - Report progress for long-running operations
 2. **Request Cancellation** - Allow clients to cancel in-flight requests
 3. **Resource Templates** - Dynamic resource URIs with parameters
-4. **Server Lifecycle Events** - Proper initialization and shutdown
-5. **Logging Control** - Server-side logging configuration
+4. **Application Lifecycle** - Server process startup and shutdown
+5. **Logging Control (Legacy)** - Deprecated MCP logging configuration
 6. **Error Handling Patterns** - Consistent error responses
 
 ---
@@ -365,9 +370,11 @@ server.setRequestHandler(ReadResourceSchema, async (request) => {
 
 ---
 
-## 4. Server Lifecycle Events
+## 4. Application Lifecycle
 
-Proper initialization and shutdown handling ensures clean resource management.
+This section covers application process startup and shutdown, not the removed
+MCP `initialize` handshake. Proper lifecycle handling ensures clean resource
+management.
 
 ### Python Lifecycle Management
 
@@ -468,9 +475,15 @@ await server.start();
 
 ---
 
-## 5. Logging Control
+## 5. Logging Control (Legacy)
 
-MCP supports server-side logging levels that clients can control.
+> [!WARNING]
+> MCP Logging is deprecated in `2026-07-28` and is eligible for removal in the
+> first specification revision released on or after July 28, 2027. The examples
+> below are for compatibility with older implementations. Use `stderr` with
+> stdio and OpenTelemetry for structured observability in new servers.
+
+Legacy MCP versions support server-side logging levels that clients can control.
 
 ### Implementing Logging Levels
 
@@ -656,51 +669,21 @@ server.setRequestHandler(CallToolSchema, async (request) => {
 
 ---
 
-## Experimental Features (MCP 2025-11-25)
+## Version-Sensitive Features
 
-These features are marked as experimental in the specification:
+### Tasks Extension
 
-### Tasks (Long-Running Operations)
-
-```python
-# Tasks allow tracking long-running operations with state
-@app.task()
-async def training_task(model_id: str, data_path: str, ctx) -> str:
-    """Long-running ML training task."""
-    
-    # Report task started
-    await ctx.report_status("running", "Initializing training...")
-    
-    # Training loop
-    for epoch in range(100):
-        await train_epoch(model_id, data_path, epoch)
-        await ctx.report_status(
-            "running",
-            f"Training epoch {epoch + 1}/100",
-            progress=epoch + 1,
-            total=100
-        )
-    
-    await ctx.report_status("completed", "Training finished")
-    return f"Model {model_id} trained successfully"
-```
+Tasks is an official, separately versioned extension in MCP `2026-07-28`. A
+server may return a task handle from a tool call, and the client drives the task
+with `tasks/get`, `tasks/update`, and `tasks/cancel`. The experimental
+`2025-11-25` Tasks API is not backward compatible, and `tasks/list` no longer
+exists.
 
 ### Tool Annotations
 
-```python
-# Annotations provide metadata about tool behavior
-@app.tool(
-    annotations={
-        "destructive": False,      # Does not modify data
-        "idempotent": True,        # Safe to retry
-        "timeout_seconds": 30,     # Expected max duration
-        "requires_approval": False # No user approval needed
-    }
-)
-async def safe_query(query: str) -> str:
-    """A read-only database query tool."""
-    return await execute_read_query(query)
-```
+Tool annotations describe behavior such as read-only, destructive, idempotent,
+or open-world operation. They are hints and must not be treated as trusted
+authorization or safety guarantees unless they come from a trusted server.
 
 ---
 
@@ -714,7 +697,7 @@ async def safe_query(query: str) -> str:
 
 ## Additional Resources
 
-- [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [JSON-RPC 2.0 Error Codes](https://www.jsonrpc.org/specification#error_object)
 - [Python SDK Examples](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples)
 - [TypeScript SDK Examples](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples)

--- a/05-AdvancedTopics/mcp-realtimesearch/README.md
+++ b/05-AdvancedTopics/mcp-realtimesearch/README.md
@@ -763,7 +763,8 @@ When implementing MCP-based web search solutions, remember these important princ
 
 5. **Robust Consent Flows**: Build robust consent and authorization flows that clearly explain what each tool does before authorizing its use, especially for tools that interact with external web resources.
 
-For complete details on MCP security and trust considerations, refer to the [official documentation](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices).
+For complete details on MCP security and trust considerations, refer to the
+[official documentation](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices).
 
 ## What's next 
 

--- a/05-AdvancedTopics/mcp-root-contexts/README.md
+++ b/05-AdvancedTopics/mcp-root-contexts/README.md
@@ -1,657 +1,146 @@
-> [DEPRECATED: 2026-07-28 RELEASE CANDIDATE](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#roots-sampling-and-logging-are-deprecated)
+# MCP Roots (Legacy Feature)
 
-# MCP Root Contexts
+> [!WARNING]
+> Roots are deprecated as of MCP `2026-07-28`. They remain in this revision for
+> compatibility and are eligible for removal in the first specification
+> revision released on or after July 28, 2027. New implementations should pass
+> directories or files through tool parameters, resource URIs, or server
+> configuration.
 
-> **Deprecation notice:** the `2026-07-28` MCP specification release candidate marks Roots as deprecated in favor of tool parameters, resource URIs, or server configuration. Roots continue to work in `2025-11-25` and for at least a year after any formal deprecation, so everything in this lesson remains valid - but new server designs should evaluate the replacement pattern. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+## Overview
 
-Root contexts are a fundamental concept in the Model Context Protocol that provide a persistent layer for maintaining conversation history and shared state across multiple requests and sessions.
+Roots let an MCP client tell a server which filesystem locations are relevant
+to the current request. A root contains a required `file://` URI and an optional
+human-readable name.
 
-## Introduction
-
-In this lesson, we will explore how to create, manage, and utilize root contexts in MCP. 
+Roots are informational hints. They are not conversation-history containers,
+protocol sessions, or an access-control mechanism. The protocol does not
+enforce that a server stays within the listed roots.
 
 ## Learning Objectives
 
 By the end of this lesson, you will be able to:
 
-- Understand the purpose and structure of root contexts
-- Create and manage root contexts using MCP client libraries
-- Implement root contexts in .NET, Java, JavaScript, and Python applications
-- Utilize root contexts for multi-turn conversations and state management
-- Implement best practices for root context management
+- Explain what MCP Roots represent and what they do not represent.
+- Recognize the current `roots/list` multi-round-trip flow.
+- Apply security controls independently of Roots.
+- Migrate new implementations to supported alternatives.
 
-## Understanding Root Contexts
+## Root Data
 
-Root contexts serve as containers that hold the history and state for a series of related interactions. They enable:
+A client returns each root as a `file://` URI with an optional display name:
 
-- **Conversation Persistence**: Maintaining coherent multi-turn conversations
-- **Memory Management**: Storing and retrieving information across interactions
-- **State Management**: Tracking progress in complex workflows
-- **Context Sharing**: Allowing multiple clients to access the same conversation state
-
-In MCP, root contexts have these key characteristics:
-
-- Each root context has a unique identifier.
-- They can contain conversation history, user preferences, and other metadata.
-- They can be created, accessed, and archived as needed.
-- They support fine-grained access control and permissions.
-
-## Root Context Lifecycle
-
-```mermaid
-flowchart TD
-    A[Create Root Context] --> B[Initialize with Metadata]
-    B --> C[Send Requests with Context ID]
-    C --> D[Update Context with Results]
-    D --> C
-    D --> E[Archive Context When Complete]
-```
-
-## Working with Root Contexts
-
-Here's an example of how to create and manage root contexts. 
-
-### C# Implementation
-
-```csharp
-// .NET Example: Root Context Management
-using Microsoft.Mcp.Client;
-using System;
-using System.Threading.Tasks;
-using System.Collections.Generic;
-
-public class RootContextExample
+```json
 {
-    private readonly IMcpClient _client;
-    private readonly IRootContextManager _contextManager;
-    
-    public RootContextExample(IMcpClient client, IRootContextManager contextManager)
+  "roots": [
     {
-        _client = client;
-        _contextManager = contextManager;
+      "uri": "file:///home/user/projects/weather-service",
+      "name": "Weather Service"
     }
-    
-    public async Task DemonstrateRootContextAsync()
-    {
-        // 1. Create a new root context
-        var contextResult = await _contextManager.CreateRootContextAsync(new RootContextCreateOptions
-        {
-            Name = "Customer Support Session",
-            Metadata = new Dictionary<string, string>
-            {
-                ["CustomerName"] = "Acme Corporation",
-                ["PriorityLevel"] = "High",
-                ["Domain"] = "Cloud Services"
-            }
-        });
-        
-        string contextId = contextResult.ContextId;
-        Console.WriteLine($"Created root context with ID: {contextId}");
-        
-        // 2. First interaction using the context
-        var response1 = await _client.SendPromptAsync(
-            "I'm having issues scaling my web service deployment in the cloud.", 
-            new SendPromptOptions { RootContextId = contextId }
-        );
-        
-        Console.WriteLine($"First response: {response1.GeneratedText}");
-        
-        // Second interaction - the model will have access to the previous conversation
-        var response2 = await _client.SendPromptAsync(
-            "Yes, we're using containerized deployments with Kubernetes.", 
-            new SendPromptOptions { RootContextId = contextId }
-        );
-        
-        Console.WriteLine($"Second response: {response2.GeneratedText}");
-        
-        // 3. Add metadata to the context based on conversation
-        await _contextManager.UpdateContextMetadataAsync(contextId, new Dictionary<string, string>
-        {
-            ["TechnicalEnvironment"] = "Kubernetes",
-            ["IssueType"] = "Scaling"
-        });
-        
-        // 4. Get context information
-        var contextInfo = await _contextManager.GetRootContextInfoAsync(contextId);
-        
-        Console.WriteLine("Context Information:");
-        Console.WriteLine($"- Name: {contextInfo.Name}");
-        Console.WriteLine($"- Created: {contextInfo.CreatedAt}");
-        Console.WriteLine($"- Messages: {contextInfo.MessageCount}");
-        
-        // 5. When the conversation is complete, archive the context
-        await _contextManager.ArchiveRootContextAsync(contextId);
-        Console.WriteLine($"Archived context {contextId}");
-    }
+  ]
 }
 ```
 
-In the preceding code we've:
+Clients should expose only locations approved by the user. Servers should treat
+the result as guidance about relevant files, not as proof of authorization.
 
-1. Created a root context for a customer support session.
-1. Sent multiple messages within that context, allowing the model to maintain state.
-1. Updated the context with relevant metadata based on the conversation.
-1. Retrieved context information to understand the conversation history.
-1. Archived the context when the conversation was complete.
+## MCP 2026-07-28 Flow
 
-## Example: Root Context Implementation for financial analysis
+A client that supports Roots declares the capability in every request:
 
-In this example, we will create a root context for a financial analysis session, demonstrating how to maintain state across multiple interactions.
-
-### Java Implementation
-
-```java
-// Java Example: Root Context Implementation
-package com.example.mcp.contexts;
-
-import com.mcp.client.McpClient;
-import com.mcp.client.ContextManager;
-import com.mcp.models.RootContext;
-import com.mcp.models.McpResponse;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-public class RootContextsDemo {
-    private final McpClient client;
-    private final ContextManager contextManager;
-    
-    public RootContextsDemo(String serverUrl) {
-        this.client = new McpClient.Builder()
-            .setServerUrl(serverUrl)
-            .build();
-            
-        this.contextManager = new ContextManager(client);
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol/clientCapabilities": {
+      "roots": {}
     }
-    
-    public void demonstrateRootContext() throws Exception {
-        // Create context metadata
-        Map<String, String> metadata = new HashMap<>();
-        metadata.put("projectName", "Financial Analysis");
-        metadata.put("userRole", "Financial Analyst");
-        metadata.put("dataSource", "Q1 2025 Financial Reports");
-        
-        // 1. Create a new root context
-        RootContext context = contextManager.createRootContext("Financial Analysis Session", metadata);
-        String contextId = context.getId();
-        
-        System.out.println("Created context: " + contextId);
-        
-        // 2. First interaction
-        McpResponse response1 = client.sendPrompt(
-            "Analyze the trends in Q1 financial data for our technology division",
-            contextId
-        );
-        
-        System.out.println("First response: " + response1.getGeneratedText());
-        
-        // 3. Update context with important information gained from response
-        contextManager.addContextMetadata(contextId, 
-            Map.of("identifiedTrend", "Increasing cloud infrastructure costs"));
-        
-        // Second interaction - using the same context
-        McpResponse response2 = client.sendPrompt(
-            "What's driving the increase in cloud infrastructure costs?",
-            contextId
-        );
-        
-        System.out.println("Second response: " + response2.getGeneratedText());
-        
-        // 4. Generate a summary of the analysis session
-        McpResponse summaryResponse = client.sendPrompt(
-            "Summarize our analysis of the technology division financials in 3-5 key points",
-            contextId
-        );
-        
-        // Store the summary in context metadata
-        contextManager.addContextMetadata(contextId, 
-            Map.of("analysisSummary", summaryResponse.getGeneratedText()));
-            
-        // Get updated context information
-        RootContext updatedContext = contextManager.getRootContext(contextId);
-        
-        System.out.println("Context Information:");
-        System.out.println("- Created: " + updatedContext.getCreatedAt());
-        System.out.println("- Last Updated: " + updatedContext.getLastUpdatedAt());
-        System.out.println("- Analysis Summary: " + 
-            updatedContext.getMetadata().get("analysisSummary"));
-            
-        // 5. Archive context when done
-        contextManager.archiveContext(contextId);
-        System.out.println("Context archived");
-    }
+  }
 }
 ```
 
-In the preceding code, we've:
+While processing a client request, a server can return an
+`InputRequiredResult` containing a `roots/list` input request:
 
-1. Created a root context for a financial analysis session.
-2. Sent multiple messages within that context, allowing the model to maintain state.
-3. Updated the context with relevant metadata based on the conversation.
-4. Generated a summary of the analysis session and stored it in the context metadata.
-5. Archived the context when the conversation was complete.
-
-## Example: Root Context Management
-
-Managing root contexts effectively is crucial for maintaining conversation history and state. Below is an example of how to implement root context management.
-
-### JavaScript Implementation
-
-```javascript
-// JavaScript Example: Managing MCP Root Contexts
-const { McpClient, RootContextManager } = require('@mcp/client');
-
-class ContextSession {
-  constructor(serverUrl, apiKey = null) {
-    // Initialize the MCP client
-    this.client = new McpClient({
-      serverUrl,
-      apiKey
-    });
-    
-    // Initialize context manager
-    this.contextManager = new RootContextManager(this.client);
-  }
-  
-  /**
-   * Create a new conversation context
-   * @param {string} sessionName - Name of the conversation session
-   * @param {Object} metadata - Additional metadata for the context
-   * @returns {Promise<string>} - Context ID
-   */
-  async createConversationContext(sessionName, metadata = {}) {
-    try {
-      const contextResult = await this.contextManager.createRootContext({
-        name: sessionName,
-        metadata: {
-          ...metadata,
-          createdAt: new Date().toISOString(),
-          status: 'active'
-        }
-      });
-      
-      console.log(`Created root context '${sessionName}' with ID: ${contextResult.id}`);
-      return contextResult.id;
-    } catch (error) {
-      console.error('Error creating root context:', error);
-      throw error;
+```json
+{
+  "resultType": "input_required",
+  "inputRequests": {
+    "workspaceRoots": {
+      "method": "roots/list"
     }
-  }
-  
-  /**
-   * Send a message in an existing context
-   * @param {string} contextId - The root context ID
-   * @param {string} message - The user's message
-   * @param {Object} options - Additional options
-   * @returns {Promise<Object>} - Response data
-   */
-  async sendMessage(contextId, message, options = {}) {
-    try {
-      // Send the message using the specified context
-      const response = await this.client.sendPrompt(message, {
-        rootContextId: contextId,
-        temperature: options.temperature || 0.7,
-        allowedTools: options.allowedTools || []
-      });
-      
-      // Optionally store important insights from the conversation
-      if (options.storeInsights) {
-        await this.storeConversationInsights(contextId, message, response.generatedText);
+  },
+  "requestState": "opaque-state-from-server"
+}
+```
+
+The client gathers the approved roots and retries the original request with the
+matching `inputResponses` and unchanged `requestState`. This multi-round-trip
+pattern keeps the protocol stateless; there is no `initialize` handshake or
+protocol-level session.
+
+## Legacy 2025-11-25 Behavior
+
+In MCP `2025-11-25`, clients advertised Roots during initialization. A server
+could issue a direct `roots/list` request, and a client could send
+`notifications/roots/list_changed` when its roots changed.
+
+That lifecycle is legacy behavior. Do not combine its initialization or
+notification examples with a `2026-07-28` implementation.
+
+## Recommended Replacements
+
+### Tool Parameters
+
+Make the required directory or file explicit in the tool schema:
+
+```json
+{
+  "name": "analyze_project",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "projectDirectory": {
+        "type": "string",
+        "description": "Approved project directory to analyze"
       }
-      
-      return {
-        message: response.generatedText,
-        toolCalls: response.toolCalls || [],
-        contextId
-      };
-    } catch (error) {
-      console.error(`Error sending message in context ${contextId}:`, error);
-      throw error;
-    }
-  }
-  
-  /**
-   * Store important insights from a conversation
-   * @param {string} contextId - The root context ID
-   * @param {string} userMessage - User's message
-   * @param {string} aiResponse - AI's response
-   */
-  async storeConversationInsights(contextId, userMessage, aiResponse) {
-    try {
-      // Extract potential insights (in a real app, this would be more sophisticated)
-      const combinedText = userMessage + "\n" + aiResponse;
-      
-      // Simple heuristic to identify potential insights
-      const insightWords = ["important", "key point", "remember", "significant", "crucial"];
-      
-      const potentialInsights = combinedText
-        .split(".")
-        .filter(sentence => 
-          insightWords.some(word => sentence.toLowerCase().includes(word))
-        )
-        .map(sentence => sentence.trim())
-        .filter(sentence => sentence.length > 10);
-      
-      // Store insights in context metadata
-      if (potentialInsights.length > 0) {
-        const insights = {};
-        potentialInsights.forEach((insight, index) => {
-          insights[`insight_${Date.now()}_${index}`] = insight;
-        });
-        
-        await this.contextManager.updateContextMetadata(contextId, insights);
-        console.log(`Stored ${potentialInsights.length} insights in context ${contextId}`);
-      }
-    } catch (error) {
-      console.warn('Error storing conversation insights:', error);
-      // Non-critical error, so just log warning
-    }
-  }
-  
-  /**
-   * Get summary information about a context
-   * @param {string} contextId - The root context ID
-   * @returns {Promise<Object>} - Context information
-   */
-  async getContextInfo(contextId) {
-    try {
-      const contextInfo = await this.contextManager.getContextInfo(contextId);
-      
-      return {
-        id: contextInfo.id,
-        name: contextInfo.name,
-        created: new Date(contextInfo.createdAt).toLocaleString(),
-        lastUpdated: new Date(contextInfo.lastUpdatedAt).toLocaleString(),
-        messageCount: contextInfo.messageCount,
-        metadata: contextInfo.metadata,
-        status: contextInfo.status
-      };
-    } catch (error) {
-      console.error(`Error getting context info for ${contextId}:`, error);
-      throw error;
-    }
-  }
-  
-  /**
-   * Generate a summary of the conversation in a context
-   * @param {string} contextId - The root context ID
-   * @returns {Promise<string>} - Generated summary
-   */
-  async generateContextSummary(contextId) {
-    try {
-      // Ask the model to generate a summary of the conversation so far
-      const response = await this.client.sendPrompt(
-        "Please summarize our conversation so far in 3-4 sentences, highlighting the main points discussed.",
-        { rootContextId: contextId, temperature: 0.3 }
-      );
-      
-      // Store the summary in context metadata
-      await this.contextManager.updateContextMetadata(contextId, {
-        conversationSummary: response.generatedText,
-        summarizedAt: new Date().toISOString()
-      });
-      
-      return response.generatedText;
-    } catch (error) {
-      console.error(`Error generating context summary for ${contextId}:`, error);
-      throw error;
-    }
-  }
-  
-  /**
-   * Archive a context when it's no longer needed
-   * @param {string} contextId - The root context ID
-   * @returns {Promise<Object>} - Result of the archive operation
-   */
-  async archiveContext(contextId) {
-    try {
-      // Generate a final summary before archiving
-      const summary = await this.generateContextSummary(contextId);
-      
-      // Archive the context
-      await this.contextManager.archiveContext(contextId);
-      
-      return {
-        status: "archived",
-        contextId,
-        summary
-      };
-    } catch (error) {
-      console.error(`Error archiving context ${contextId}:`, error);
-      throw error;
-    }
+    },
+    "required": ["projectDirectory"]
   }
 }
-
-// Example usage
-async function demonstrateContextSession() {
-  const session = new ContextSession('https://mcp-server-example.com');
-  
-  try {
-    // 1. Create a new context for a product support conversation
-    const contextId = await session.createConversationContext(
-      'Product Support - Database Performance',
-      {
-        customer: 'Globex Corporation',
-        product: 'Enterprise Database',
-        severity: 'Medium',
-        supportAgent: 'AI Assistant'
-      }
-    );
-    
-    // 2. First message in the conversation
-    const response1 = await session.sendMessage(
-      contextId,
-      "I'm experiencing slow query performance on our database cluster after the latest update.",
-      { storeInsights: true }
-    );
-    console.log('Response 1:', response1.message);
-    
-    // Follow-up message in the same context
-    const response2 = await session.sendMessage(
-      contextId,
-      "Yes, we've already checked the indexes and they seem to be properly configured.",
-      { storeInsights: true }
-    );
-    console.log('Response 2:', response2.message);
-    
-    // 3. Get information about the context
-    const contextInfo = await session.getContextInfo(contextId);
-    console.log('Context Information:', contextInfo);
-    
-    // 4. Generate and display conversation summary
-    const summary = await session.generateContextSummary(contextId);
-    console.log('Conversation Summary:', summary);
-    
-    // 5. Archive the context when done
-    const archiveResult = await session.archiveContext(contextId);
-    console.log('Archive Result:', archiveResult);
-    
-    // 6. Handle any errors gracefully
-  } catch (error) {
-    console.error('Error in context session demonstration:', error);
-  }
-}
-
-demonstrateContextSession();
 ```
 
-In the preceding code we've:
+### Resource URIs
 
-1. Created a root context for a product support conversation with the function `createConversationContext`. In this case, the context is about database performance issues.
+Use MCP Resources when the server can expose the relevant files through stable
+URIs. This keeps discovery and retrieval explicit.
 
-1. Sent multiple messages within that context, allowing the model to maintain state with the function `sendMessage`. The messages being sent are about slow query performance and index configuration.
+### Server Configuration
 
-1. Updated the context with relevant metadata based on the conversation.
+For fixed deployments, configure allowed directories when the server starts.
+This is often clearer than discovering them during a tool call.
 
-1. Generated a summary of the conversation and stored it in the context metadata with the function `generateContextSummary`.
+## Security Requirements
 
-1. Archived the context when the conversation was complete with the function `archiveContext`.
+Whichever replacement you choose:
 
-1. Handled errors gracefully to ensure robustness.
+- Obtain user consent before exposing filesystem locations.
+- Canonicalize and validate paths to prevent traversal.
+- Enforce authorization and sandboxing independently of root values.
+- Recheck permissions when a file is accessed, not only when it is listed.
+- Avoid returning sensitive paths in logs or error messages.
 
-## Root Context for Multi-Turn Assistance
+## Key Takeaways
 
-In this example, we will create a root context for a multi-turn assistance session, demonstrating how to maintain state across multiple interactions.
+- Roots describe relevant filesystem locations; they do not store conversation
+  state.
+- Roots are guidance, not an access-control boundary.
+- MCP `2026-07-28` carries the capability per request and uses
+  `InputRequiredResult` for `roots/list`.
+- New implementations should use tool parameters, resource URIs, or server
+  configuration instead.
 
-### Python Implementation
+## Additional Resources
 
-```python
-# Python Example: Root Context for Multi-Turn Assistance
-import asyncio
-from datetime import datetime
-from mcp_client import McpClient, RootContextManager
-
-class AssistantSession:
-    def __init__(self, server_url, api_key=None):
-        self.client = McpClient(server_url=server_url, api_key=api_key)
-        self.context_manager = RootContextManager(self.client)
-    
-    async def create_session(self, name, user_info=None):
-        """Create a new root context for an assistant session"""
-        metadata = {
-            "session_type": "assistant",
-            "created_at": datetime.now().isoformat(),
-        }
-        
-        # Add user information if provided
-        if user_info:
-            metadata.update({f"user_{k}": v for k, v in user_info.items()})
-            
-        # Create the root context
-        context = await self.context_manager.create_root_context(name, metadata)
-        return context.id
-    
-    async def send_message(self, context_id, message, tools=None):
-        """Send a message within a root context"""
-        # Create options with context ID
-        options = {
-            "root_context_id": context_id
-        }
-        
-        # Add tools if specified
-        if tools:
-            options["allowed_tools"] = tools
-        
-        # Send the prompt within the context
-        response = await self.client.send_prompt(message, options)
-        
-        # Update context metadata with conversation progress
-        await self.context_manager.update_context_metadata(
-            context_id,
-            {
-                f"message_{datetime.now().timestamp()}": message[:50] + "...",
-                "last_interaction": datetime.now().isoformat()
-            }
-        )
-        
-        return response
-    
-    async def get_conversation_history(self, context_id):
-        """Retrieve conversation history from a context"""
-        context_info = await self.context_manager.get_context_info(context_id)
-        messages = await self.client.get_context_messages(context_id)
-        
-        return {
-            "context_info": context_info,
-            "messages": messages
-        }
-    
-    async def end_session(self, context_id):
-        """End an assistant session by archiving the context"""
-        # Generate a summary prompt first
-        summary_response = await self.client.send_prompt(
-            "Please summarize our conversation and any key points or decisions made.",
-            {"root_context_id": context_id}
-        )
-        
-        # Store summary in metadata
-        await self.context_manager.update_context_metadata(
-            context_id,
-            {
-                "summary": summary_response.generated_text,
-                "ended_at": datetime.now().isoformat(),
-                "status": "completed"
-            }
-        )
-        
-        # Archive the context
-        await self.context_manager.archive_context(context_id)
-        
-        return {
-            "status": "completed",
-            "summary": summary_response.generated_text
-        }
-
-# Example usage
-async def demo_assistant_session():
-    assistant = AssistantSession("https://mcp-server-example.com")
-    
-    # 1. Create session
-    context_id = await assistant.create_session(
-        "Technical Support Session",
-        {"name": "Alex", "technical_level": "advanced", "product": "Cloud Services"}
-    )
-    print(f"Created session with context ID: {context_id}")
-    
-    # 2. First interaction
-    response1 = await assistant.send_message(
-        context_id, 
-        "I'm having trouble with the auto-scaling feature in your cloud platform.",
-        ["documentation_search", "diagnostic_tool"]
-    )
-    print(f"Response 1: {response1.generated_text}")
-    
-    # Second interaction in the same context
-    response2 = await assistant.send_message(
-        context_id,
-        "Yes, I've already checked the configuration settings you mentioned, but it's still not working."
-    )
-    print(f"Response 2: {response2.generated_text}")
-    
-    # 3. Get history
-    history = await assistant.get_conversation_history(context_id)
-    print(f"Session has {len(history['messages'])} messages")
-    
-    # 4. End session
-    end_result = await assistant.end_session(context_id)
-    print(f"Session ended with summary: {end_result['summary']}")
-
-if __name__ == "__main__":
-    asyncio.run(demo_assistant_session())
-```
-
-In the preceding code we've:
-
-1. Created a root context for a technical support session with the function `create_session`. The context includes user information such as name and technical level.
-
-1. Sent multiple messages within that context, allowing the model to maintain state with the function `send_message`. The messages being sent are about issues with the auto-scaling feature.
-
-1. Retrieved conversation history using the function `get_conversation_history`, which provides context information and messages.
-
-1. Ended the session by archiving the context and generating a summary with the function `end_session`. The summary captures key points from the conversation.
-
-## Root Context Best Practices
-
-Here are some best practices for managing root contexts effectively:
-
-- **Create Focused Contexts**: Create separate root contexts for different conversation purposes or domains to maintain clarity.
-
-- **Set Expiration Policies**: Implement policies to archive or delete old contexts to manage storage and comply with data retention policies.
-
-- **Store Relevant Metadata**: Use context metadata to store important information about the conversation that might be useful later.
-
-- **Use Context IDs Consistently**: Once a context is created, use its ID consistently for all related requests to maintain continuity.
-
-- **Generate Summaries**: When a context grows large, consider generating summaries to capture essential information while managing context size.
-
-- **Implement Access Control**: For multi-user systems, implement proper access controls to ensure privacy and security of conversation contexts.
-
-- **Handle Context Limitations**: Be aware of context size limitations and implement strategies for handling very long conversations.
-
-- **Archive When Complete**: Archive contexts when conversations are complete to free resources while preserving the conversation history.
-
-## What's next
-
-- [5.5 Routing](../mcp-routing/README.md)
+- [Roots in MCP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/client/roots)
+- [Deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
+- [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md)

--- a/05-AdvancedTopics/mcp-sampling/README.md
+++ b/05-AdvancedTopics/mcp-sampling/README.md
@@ -1,10 +1,18 @@
-> [DEPRECATED: 2026-07-28 RELEASE CANDIDATE](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#roots-sampling-and-logging-are-deprecated)
+> [!WARNING]
+> Sampling is deprecated in MCP `2026-07-28`. This lesson is retained for
+> legacy implementations. New servers should integrate directly with an LLM
+> provider API.
 
 # Sampling in Model Context Protocol
 
-> **Deprecation notice:** the `2026-07-28` MCP specification release candidate marks Sampling as deprecated in favor of direct integration with LLM provider APIs. Sampling continues to work in `2025-11-25` and for at least a year after any formal deprecation, so everything in this lesson remains valid - but new server designs should evaluate the replacement pattern. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> Sampling remains in the `2026-07-28` specification for compatibility and is
+> eligible for removal in the first revision released on or after July 28,
+> 2027. Examples in this lesson may use SDK APIs that implement `2025-11-25`.
+> See [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
-Sampling is a powerful MCP feature that allows servers to request LLM completions through the client, enabling sophisticated agentic behaviors while maintaining security and privacy. The right sampling configuration can dramatically improve response quality and performance. MCP provides a standardized way to control how models generate text with specific parameters that influence randomness, creativity, and coherence.
+In legacy MCP implementations, Sampling allows servers to request LLM
+completions through the client. This lesson explains that deprecated protocol
+flow for compatibility and migration work.
 
 ## Introduction
 

--- a/05-AdvancedTopics/mcp-security-entra/README.md
+++ b/05-AdvancedTopics/mcp-security-entra/README.md
@@ -1,5 +1,11 @@
 # Securing AI Workflows: Entra ID Authentication for Model Context Protocol Servers
 
+> [!NOTE]
+> The remote server code in this lesson protects legacy `/sse` and `/message`
+> endpoints and targets MCP `2025-11-25`. Keep its identity and token-validation
+> practices, but use a `2026-07-28`-compatible Streamable HTTP transport for new
+> implementations.
+
 ## Introduction
 Securing your Model Context Protocol (MCP) server is as important as locking the front door of your house. Leaving your MCP server open exposes your tools and data to unauthorized access, which can lead to security breaches. Microsoft Entra ID provides a robust cloud-based identity and access management solution, helping ensure that only authorized users and applications can interact with your MCP server. In this section, you’ll learn how to protect your AI workflows using Entra ID authentication.
 

--- a/05-AdvancedTopics/mcp-security/README.md
+++ b/05-AdvancedTopics/mcp-security/README.md
@@ -1,20 +1,34 @@
 # MCP Security Best Practices - Advanced Implementation Guide
 
-> **Current Standard**: This guide reflects [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) security requirements and official [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices).
+> **Current standard:** This guide reflects
+> [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
+> and the official
+> [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices).
 
-> **Looking ahead:** the `2026-07-28` release candidate hardens authorization further — clients must validate the `iss` parameter on authorization responses (RFC 9207), declare an OpenID Connect `application_type` during Dynamic Client Registration, and bind registered credentials to the issuing authorization server. It also formally prohibits sessions for authentication, consistent with the "MUST NOT use sessions for authentication" rule already called out below. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md) for the full list of authorization SEPs.
+> **Authorization update:** MCP `2026-07-28` requires clients to validate the
+> `iss` parameter on authorization responses (RFC 9207) and bind credentials to
+> the issuing authorization server. Dynamic Client Registration is deprecated;
+> new implementations should use Client ID Metadata Documents. Protocol
+> sessions must not be used for authentication. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
 Security is critical for MCP implementations, especially in enterprise environments. This advanced guide explores comprehensive security practices for production MCP deployments, addressing both traditional security concerns and AI-specific threats unique to the Model Context Protocol.
 
 ## Introduction
 
-The Model Context Protocol (MCP) introduces unique security challenges that extend beyond traditional software security. As AI systems gain access to tools, data, and external services, new attack vectors emerge including prompt injection, tool poisoning, session hijacking, confused deputy problems, and token passthrough vulnerabilities.
+The Model Context Protocol (MCP) introduces unique security challenges that
+extend beyond traditional software security. As AI systems gain access to tools,
+data, and external services, new attack vectors emerge including prompt
+injection, tool poisoning, application-session hijacking, confused deputy
+problems, and token passthrough vulnerabilities.
 
-This lesson explores advanced security implementations based on the latest MCP specification (2025-11-25), Microsoft security solutions, and established enterprise security patterns.
+This lesson explores advanced security implementations based on MCP
+Specification `2026-07-28`, Microsoft security solutions, and established
+enterprise security patterns.
 
 ### **Core Security Principles**
 
-**From MCP Specification (2025-11-25):**
+**From MCP Specification `2026-07-28`:**
 
 - **Explicit Prohibitions**: MCP servers **MUST NOT** accept tokens not issued for them, and **MUST NOT** use sessions for authentication
 - **Mandatory Verification**: All inbound requests **MUST** be verified, and user consent **MUST** be obtained for proxy operations
@@ -34,7 +48,7 @@ By the end of this advanced lesson, you will be able to:
 
 ## **MANDATORY Security Requirements**
 
-### **Critical Requirements from MCP Specification (2025-11-25):**
+### **Critical Requirements from MCP Specification `2026-07-28`**
 
 ```yaml
 Authentication & Authorization:
@@ -43,7 +57,8 @@ Authentication & Authorization:
   request_verification: "MUST verify ALL inbound requests"
   
 Proxy Operations:  
-  user_consent: "MUST obtain consent for dynamic client registration"
+    user_consent: "MUST obtain consent before authorization and sensitive actions"
+    client_registration: "Use Client ID Metadata Documents; DCR is deprecated"
   oauth_security: "MUST implement OAuth 2.1 with PKCE"
   redirect_validation: "MUST validate redirect URIs strictly"
   
@@ -59,7 +74,8 @@ Modern MCP implementations benefit from the specification's evolution toward ext
 
 ### **Microsoft Entra ID Integration**
 
-The current MCP specification (2025-11-25) allows delegation to external identity providers like Microsoft Entra ID, providing enterprise-grade security features:
+MCP Specification `2026-07-28` allows delegation to external identity providers
+like Microsoft Entra ID, providing enterprise-grade security features:
 
 **Security Benefits:**
 - Enterprise-grade multi-factor authentication (MFA)
@@ -903,7 +919,7 @@ async def log_security_event(event_data: Dict):
 
 ### **1. Confused Deputy Attack Prevention**
 
-**Enhanced Implementation Following MCP Specification (2025-11-25):**
+**Enhanced implementation following MCP Specification `2026-07-28`:**
 
 ```python
 import asyncio
@@ -1767,9 +1783,9 @@ Monitoring & Response:
 
 ### **References & Resources**
 
-- **[MCP Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/)**
-- **[MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices)**  
-- **[MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)**
+- **[MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)**
+- **[MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)**
+- **[MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)**
 - **[Microsoft Prompt Shields](https://learn.microsoft.com/azure/ai-services/content-safety/concepts/jailbreak-detection)**
 - **[Azure Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/)**
 - **[OAuth 2.0 Security Best Practices (RFC 9700)](https://datatracker.ietf.org/doc/html/rfc9700)**
@@ -1777,7 +1793,9 @@ Monitoring & Response:
 
 ---
 
-> **Security Notice**: This advanced implementation guide reflects current MCP specification (2025-11-25) requirements. Always verify against the latest official documentation and consider your specific security requirements and threat model when implementing these controls.
+> **Security notice:** This advanced implementation guide reflects MCP
+> Specification `2026-07-28`. Always verify against the latest official
+> documentation and apply controls appropriate to your threat model.
 
 ## What's next
 

--- a/05-AdvancedTopics/mcp-transport/README.md
+++ b/05-AdvancedTopics/mcp-transport/README.md
@@ -1,23 +1,39 @@
 # MCP Custom Transports - Advanced Implementation Guide
 
-The Model Context Protocol (MCP) provides flexibility in transport mechanisms, allowing custom implementations for specialized enterprise environments. This advanced guide explores custom transport implementations using Azure Event Grid and Azure Event Hubs as practical examples for building scalable, cloud-native MCP solutions.
+The Model Context Protocol (MCP) permits custom transport implementations for
+specialized environments. This advanced guide explores Azure Event Grid and
+Azure Event Hubs as architecture patterns. They are not standard MCP transports
+and require both endpoints to agree on the custom mapping.
 
-> **Looking ahead:** this guide is written against **MCP Specification 2025-11-25**, where session ordering must be preserved per session (see Message Protocol below). The `2026-07-28` release candidate removes the protocol-level session entirely and requires `Mcp-Method`/`Mcp-Name` headers so gateways and custom transports can route per-request instead of per-session. See [What's Changing in MCP: The 2026-07-28 Release Candidate](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
+> **MCP `2026-07-28` scope:** the current protocol has no protocol-level
+> sessions, so custom transports must not depend on session affinity or
+> per-session ordering. The `Mcp-Method` and conditional `Mcp-Name` headers are
+> requirements of the standard Streamable HTTP transport; a non-HTTP transport
+> needs an equivalent, explicitly agreed mapping if intermediaries must route
+> without decoding the JSON-RPC body. See
+> [What's Changed in MCP: The 2026-07-28 Specification](../../01-CoreConcepts/mcp-2026-07-28-release-candidate.md).
 
 ## Introduction
 
-While MCP's standard transports (stdio and HTTP streaming) serve most use cases, enterprise environments often require specialized transport mechanisms for improved scalability, reliability, and integration with existing cloud infrastructure. Custom transports enable MCP to leverage cloud-native messaging services for asynchronous communication, event-driven architectures, and distributed processing.
+MCP's standard transports are stdio and Streamable HTTP. Some enterprise
+environments use a custom mapping to integrate with existing messaging
+infrastructure, but doing so can reduce interoperability with MCP hosts and
+SDKs that implement only the standard transports.
 
-This lesson explores advanced transport implementations based on the latest MCP specification (2025-11-25), Azure messaging services, and established enterprise integration patterns.
+This lesson applies the stateless requirements of MCP Specification
+`2026-07-28` to Azure messaging services and established enterprise integration
+patterns.
 
 ### **MCP Transport Architecture**
 
-**From MCP Specification (2025-11-25):**
+**From MCP Specification `2026-07-28`:**
 
-- **Standard Transports**: stdio (recommended), HTTP streaming (for remote scenarios)
-- **Custom Transports**: Any transport that implements the MCP message exchange protocol
+- **Standard Transports**: stdio and Streamable HTTP
+- **Custom Transports**: Optional, implementation-specific mappings agreed by
+    both endpoints
 - **Message Format**: JSON-RPC 2.0 with MCP-specific extensions
-- **Bidirectional Communication**: Full duplex communication required for notifications and responses
+- **Self-contained Requests**: No protocol session or handshake is available
+    to carry state between requests
 
 ## Learning Objectives
 
@@ -32,23 +48,23 @@ By the end of this advanced lesson, you will be able to:
 
 ## **Transport Requirements**
 
-### **Core Requirements from MCP Specification (2025-11-25):**
+### **Core Requirements for MCP `2026-07-28`**
 
 ```yaml
 Message Protocol:
   format: "JSON-RPC 2.0 with MCP extensions"
-  bidirectional: "Full duplex communication required"
-  ordering: "Message ordering must be preserved per session"
+    correlation: "Match responses to requests by JSON-RPC id"
+    state: "Each request must be self-contained"
   
 Transport Layer:
   reliability: "Transport MUST handle connection failures gracefully"
   security: "Transport MUST support secure communication"
-  identification: "Each session MUST have unique identifier"
+    identification: "Carry protocol version, capabilities, and identity per request"
   
 Custom Transport:
-  compliance: "MUST implement complete MCP message exchange"
+    compliance: "Map the selected MCP revision without adding session assumptions"
   extensibility: "MAY add transport-specific features"
-  interoperability: "MUST maintain protocol compatibility"
+    interoperability: "Both endpoints MUST agree on the custom mapping"
 ```
 
 ## **Azure Event Grid Transport Implementation**
@@ -827,7 +843,7 @@ The examples provided demonstrate production-ready patterns for implementing cus
 
 ## **Additional Resources**
 
-- [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [Azure Event Grid Documentation](https://docs.microsoft.com/azure/event-grid/)
 - [Azure Event Hubs Documentation](https://docs.microsoft.com/azure/event-hubs/)
 - [Azure Functions Event Grid Trigger](https://docs.microsoft.com/azure/azure-functions/functions-bindings-event-grid)
@@ -837,8 +853,9 @@ The examples provided demonstrate production-ready patterns for implementing cus
 
 ---
 
-> *This guide focuses on practical implementation patterns for production MCP systems. Always validate transport implementations against your specific requirements and Azure service limits.*
-> **Current Standard**: This guide reflects [MCP Specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25/) transport requirements and advanced transport patterns for enterprise environments.
+> *This guide focuses on custom architecture patterns. Validate protocol
+> behavior against [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/),
+> and validate Azure usage against your requirements and service limits.*
 
 
 ## What's Next

--- a/06-CommunityContributions/README.md
+++ b/06-CommunityContributions/README.md
@@ -37,7 +37,7 @@ The MCP ecosystem consists of various components and participants that work toge
 
 - [MCP GitHub Organization](https://github.com/modelcontextprotocol)
 - [MCP Documentation](https://modelcontextprotocol.io/)
-- [MCP Specification](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions)
 - [MCP Examples & Servers Repository](https://github.com/modelcontextprotocol/servers)
 
@@ -348,7 +348,9 @@ One of the most valuable ways to contribute to the MCP ecosystem is by creating 
 
 Several frameworks are available to simplify MCP server development:
 
-1. **Official SDKs** (aligned with [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/)):
+1. **Official SDKs** (check the
+    [SDK documentation](https://modelcontextprotocol.io/docs/sdk) for each
+    SDK's supported protocol revisions):
    - [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk)
    - [Python SDK](https://github.com/modelcontextprotocol/python-sdk)
    - [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk)

--- a/07-LessonsfromEarlyAdoption/README.md
+++ b/07-LessonsfromEarlyAdoption/README.md
@@ -569,7 +569,7 @@ The Model Context Protocol (MCP) is rapidly shaping the future of standardized, 
 - [MCP GitHub Repository (Microsoft)](https://github.com/microsoft/mcp)
 - [MCP Resources Directory (Sample Prompts, Tools, and Resource Definitions)](https://github.com/microsoft/mcp/tree/main/Resources)
 - [MCP Community & Documentation](https://modelcontextprotocol.io/introduction)
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [Azure MCP Documentation](https://aka.ms/azmcp)
 - [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/mcp/) - Security best practices
 - [Playwright MCP Server GitHub Repository](https://github.com/microsoft/playwright-mcp)

--- a/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/README.md
+++ b/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/README.md
@@ -14,6 +14,12 @@ _(Click the image above to view video of this lesson)_
 
 Welcome to the **Model Context Protocol (MCP) Workshop**! This comprehensive hands-on workshop combines two cutting-edge technologies to revolutionize AI application development:
 
+> **Compatibility note:** the workshop code was built and tested with MCP
+> `2025-11-25`, as shown by the badge above. Use the
+> [current `2026-07-28` specification](https://modelcontextprotocol.io/specification/2026-07-28/)
+> for new protocol implementations and review SDK release notes before
+> migrating the labs.
+
 - **🔗 Model Context Protocol (MCP)**: An open standard for seamless AI-tool integration
 - **🛠️ Microsoft Foundry Toolkit Extension for VS Code**: Microsoft's powerful AI development extension
 
@@ -203,7 +209,7 @@ By completing this workshop, you will achieve mastery in:
 
 ## 📖 Additional Resources
 
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+- [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
 - [Microsoft Foundry Toolkit GitHub Repository](https://github.com/microsoft/vscode-ai-toolkit)
 - [Sample MCP Servers Collection](https://github.com/modelcontextprotocol/servers)
 - [Best Practices Guide](https://modelcontextprotocol.io/docs/best-practices)

--- a/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/lab3/README.md
+++ b/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/lab3/README.md
@@ -1,5 +1,10 @@
 # 🔧 Module 3: Advanced MCP Development with Microsoft Foundry Toolkit
 
+> [!NOTE]
+> Inspector URLs in this lab use the legacy `/sse` endpoint and target the
+> pinned MCP SDK `1.9.3` and Inspector `0.14.0` dependencies. They are not
+> current `2026-07-28` Streamable HTTP examples.
+
 ![Duration](https://img.shields.io/badge/Duration-20_minutes-blue?style=flat-square)
 ![Microsoft Foundry Toolkit](https://img.shields.io/badge/Microsoft_Foundry_Toolkit-Required-orange?style=flat-square)
 ![Python](https://img.shields.io/badge/Python-3.10+-green?style=flat-square)

--- a/11-MCPServerHandsOnLabs/00-Introduction/README.md
+++ b/11-MCPServerHandsOnLabs/00-Introduction/README.md
@@ -1,5 +1,10 @@
 # Introduction to MCP Database Integration
 
+> [!NOTE]
+> Diagrams or code in this learning path that use HTTP/SSE or initialization
+> options reflect the sample's MCP `2025-11-25` dependencies. For new
+> implementations, use `2026-07-28` stateless requests and Streamable HTTP.
+
 ## 🎯 What This Lab Covers
 
 This introduction lab provides a comprehensive overview of building Model Context Protocol (MCP) servers with database integration. You'll understand the business case, technical architecture, and real-world applications through the Zava Retail analytics use case at https://github.com/microsoft/MCP-Server-and-PostgreSQL-Sample-Retail.

--- a/11-MCPServerHandsOnLabs/09-VS-Code/README.md
+++ b/11-MCPServerHandsOnLabs/09-VS-Code/README.md
@@ -1,5 +1,11 @@
 # VS Code Integration
 
+> [!NOTE]
+> The `initializationOptions` settings in this lab target the sample's MCP
+> `2025-11-25` handshake. MCP `2026-07-28` removes the initialization handshake;
+> use a host and SDK that support per-request metadata and `server/discover`
+> when migrating this sample.
+
 ## 🎯 What This Lab Covers
 
 This lab provides comprehensive guidance on integrating your MCP server with VS Code to enable natural language queries through AI Chat. You'll learn to configure VS Code for optimal MCP usage, debug server connections, and leverage the full power of AI-assisted database interactions.

--- a/11-MCPServerHandsOnLabs/README.md
+++ b/11-MCPServerHandsOnLabs/README.md
@@ -9,7 +9,7 @@ Whether you're a backend developer, AI engineer, or data architect, this guide p
 ## 🔗 Official MCP Resources
 
 - 📘 [MCP Documentation](https://modelcontextprotocol.io/) – Detailed tutorials and user guides
-- 📜 [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/) – Protocol architecture and technical references
+- 📜 [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/) – Protocol architecture and technical references
 - 🧑‍💻 [MCP GitHub Repository](https://github.com/modelcontextprotocol) – Open-source SDKs, tools, and code samples
 - 🌐 [MCP Community](https://github.com/orgs/modelcontextprotocol/discussions) – Join discussions and contribute to the community
 - 🔒 [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/mcp/) – Security best practices and risk mitigations

--- a/12-tooling/README.md
+++ b/12-tooling/README.md
@@ -7,7 +7,7 @@ Here you will learn how to use tools that uses MCP. Your experience using these 
 ## 🔗 Official MCP Resources
 
 - 📘 [MCP Documentation](https://modelcontextprotocol.io/) – Detailed tutorials and user guides
-- 📜 [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/) – Protocol architecture and technical references
+- 📜 [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/) – Protocol architecture and technical references
 - 🧑‍💻 [MCP GitHub Repository](https://github.com/modelcontextprotocol) – Open-source SDKs, tools, and code samples
 - 🌐 [MCP Community](https://github.com/orgs/modelcontextprotocol/discussions) – Join discussions and contribute to the community
 - 🔒 [OWASP MCP Top 10](https://microsoft.github.io/mcp-azure-security-guide/mcp/) – Security best practices and risk mitigations

--- a/README.md
+++ b/README.md
@@ -62,13 +62,20 @@ By the time you complete this journey, you'll have the confidence to build your 
 
 ### Official Documentation and Specifications
 
-This curriculum is aligned with **MCP Specification 2025-11-25** (the latest stable release). The MCP specification uses date-based versioning (YYYY-MM-DD format) to ensure clear protocol version tracking.
+The current protocol revision is **MCP Specification 2026-07-28**. The MCP
+specification uses date-based versioning (YYYY-MM-DD format) to make protocol
+compatibility explicit.
 
-> **Looking ahead:** a release candidate for the next specification version, **2026-07-28**, is scheduled to ship on July 28, 2026. It makes the protocol stateless at the transport layer, formalizes an Extensions framework (MCP Apps, Tasks), hardens authorization, and deprecates Roots, Sampling, and Logging. See [What's Changing in MCP: The 2026-07-28 Release Candidate](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md) for a full breakdown.
+> **Version note:** this curriculum teaches the current `2026-07-28`
+> concepts, including stateless requests, the Extensions framework, and the
+> deprecation of Roots, Sampling, and Logging. Some hands-on examples remain
+> explicitly versioned to `2025-11-25` while SDK support catches up. See
+> [What's Changed in MCP: The 2026-07-28 Specification](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md)
+> for the changes and migration guidance.
 
 These resources become more valuable as your understanding grows, but don't feel pressured to read everything immediately. Start with the areas that interest you most!
 - 📘 [MCP Documentation](https://modelcontextprotocol.io/) – This is your go-to resource for step-by-step tutorials and user guides. The documentation is written with beginners in mind, providing clear examples you can follow along with at your own pace.
-- 📜 [MCP Specification](https://modelcontextprotocol.io/specification/2025-11-25) – Think of this as your comprehensive reference manual. As you work through the curriculum, you'll find yourself returning here to look up specific details and explore advanced features.
+- 📜 [MCP Specification](https://modelcontextprotocol.io/specification/2026-07-28) – Think of this as your comprehensive reference manual. As you work through the curriculum, you'll find yourself returning here to look up specific details and explore advanced features.
 - 📜 [MCP Specification Versioning](https://modelcontextprotocol.io/specification/versioning) – This contains information about protocol version history and how MCP uses date-based versioning (YYYY-MM-DD format).
 - 🧑‍💻 [MCP GitHub Repository](https://github.com/modelcontextprotocol) –  Here you'll find SDKs, tools, and code samples in multiple programming languages. It's like a treasure trove of practical examples and ready-to-use components.
 - 🌐 [MCP Community](https://github.com/orgs/modelcontextprotocol/discussions) – Join fellow learners and experienced developers in discussions about MCP. It's a supportive community where questions are welcome and knowledge is shared freely.


### PR DESCRIPTION
# Purpose

Update the English curriculum for the final MCP `2026-07-28` specification and remove statements that could confuse readers about the current protocol revision.

- Document the stateless request model, `server/discover`, required Streamable HTTP headers, and the Tasks extension.
- Correct Roots, Sampling, Elicitation, Logging, authorization, and transport guidance.
- Clearly label examples that still target MCP `2025-11-25` or legacy HTTP+SSE tooling.
- Leave generated translations and translated images unchanged.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Validation

- `git diff --check`
- English source protocol terminology audit
- Rewritten Roots lesson passes Markdown lint
- Confirmed no files under `translations/` or `translated_images/` changed