### PR TITLE
sept update

### DIFF
--- a/02-Security/mcp-best-practices.md
+++ b/02-Security/mcp-best-practices.md
@@ -12,9 +12,7 @@ unique to MCP deployments.
 
 1. **Token Validation**: MCP servers **MUST NOT** accept any tokens that were not explicitly issued for the MCP server itself
 2. **Authorization Verification**: MCP servers implementing authorization **MUST** verify ALL inbound requests and **MUST NOT** use sessions for authentication  
-3. **User Consent**: MCP proxy servers using static third-party client IDs
-	**MUST** obtain explicit consent for each MCP client before forwarding an
-	authorization flow
+3. **User Consent**: MCP proxy servers using static third-party client IDs **MUST** obtain explicit consent for each MCP client before forwarding an authorization flow
 4. **State Handle Security**: MCP servers **MUST NOT** treat possession of an
 	application state handle as authentication and **MUST** authorize every
 	request that uses one

--- a/02-Security/mcp-best-practices.md
+++ b/02-Security/mcp-best-practices.md
@@ -1,6 +1,10 @@
-# MCP Security Best Practices 2025
+# MCP Security Best Practices - September 2026 Update
 
-This comprehensive guide outlines essential security best practices for implementing Model Context Protocol (MCP) systems based on the latest **MCP Specification 2025-11-25** and current industry standards. These practices address both traditional security concerns and AI-specific threats unique to MCP deployments.
+This comprehensive guide outlines essential security best practices for
+implementing Model Context Protocol (MCP) systems based on
+**MCP Specification 2026-07-28** and current industry standards. These
+practices address both traditional security concerns and AI-specific threats
+unique to MCP deployments.
 
 ## Critical Security Requirements
 
@@ -8,8 +12,12 @@ This comprehensive guide outlines essential security best practices for implemen
 
 1. **Token Validation**: MCP servers **MUST NOT** accept any tokens that were not explicitly issued for the MCP server itself
 2. **Authorization Verification**: MCP servers implementing authorization **MUST** verify ALL inbound requests and **MUST NOT** use sessions for authentication  
-3. **User Consent**: MCP proxy servers using static client IDs **MUST** obtain explicit user consent for each dynamically registered client
-4. **Secure Session IDs**: MCP servers **MUST** use cryptographically secure, non-deterministic session IDs generated with secure random number generators
+3. **User Consent**: MCP proxy servers using static third-party client IDs
+	**MUST** obtain explicit consent for each MCP client before forwarding an
+	authorization flow
+4. **State Handle Security**: MCP servers **MUST NOT** treat possession of an
+	application state handle as authentication and **MUST** authorize every
+	request that uses one
 
 ## Core Security Practices
 
@@ -21,18 +29,25 @@ This comprehensive guide outlines essential security best practices for implemen
 
 ### 2. Authentication & Authorization Excellence  
 - **External Identity Providers**: Delegate authentication to established identity providers (Microsoft Entra ID, OAuth 2.1 providers) rather than implementing custom authentication
+- **Client Registration**: Prefer Client ID Metadata Documents or
+	pre-registration; use deprecated Dynamic Client Registration only for
+	compatibility
 - **Fine-grained Permissions**: Implement granular, tool-specific permissions following the principle of least privilege
 - **Token Lifecycle Management**: Use short-lived access tokens with secure rotation and proper audience validation
 - **Multi-Factor Authentication**: Require MFA for all administrative access and sensitive operations
 
 ### 3. Secure Communication Protocols
-- **Transport Layer Security**: Use HTTPS/TLS 1.3 for all MCP communications with proper certificate validation
+- **Transport Layer Security**: Use HTTPS with proper certificate validation
+	for remote HTTP MCP communications; use process isolation and environment
+	credentials for local stdio servers
 - **End-to-End Encryption**: Implement additional encryption layers for highly sensitive data in transit and at rest
 - **Certificate Management**: Maintain proper certificate lifecycle management with automated renewal processes
-- **Protocol Version Enforcement**: Use the current MCP protocol version (2025-11-25) with proper version negotiation.
+- **Protocol Version Enforcement**: Use MCP `2026-07-28`, include the required
+	version metadata on every request, and reject unsupported versions
 
 ### 4. Advanced Rate Limiting & Resource Protection
-- **Multi-layer Rate Limiting**: Implement rate limiting at user, session, tool, and resource levels to prevent abuse
+- **Multi-layer Rate Limiting**: Implement rate limiting by user, credential,
+  operation, tool, and resource to prevent abuse
 - **Adaptive Rate Limiting**: Use machine learning-based rate limiting that adapts to usage patterns and threat indicators
 - **Resource Quota Management**: Set appropriate limits for computational resources, memory usage, and execution time
 - **DDoS Protection**: Deploy comprehensive DDoS protection and traffic analysis systems
@@ -53,13 +68,19 @@ This comprehensive guide outlines essential security best practices for implemen
 - **Token Passthrough Prevention**: Explicitly prohibit token passthrough patterns that bypass security controls
 - **Audience Validation**: Always verify token audience claims match the intended MCP server identity
 - **Claims-based Authorization**: Implement fine-grained authorization based on token claims and user attributes
-- **Token Binding**: Bind tokens to specific sessions, users, or devices where appropriate
+- **Token Binding**: Validate that tokens target the intended MCP resource and
+	bind application state handles server-side to the authenticated principal
 
-### 8. Secure Session Management
-- **Cryptographic Session IDs**: Generate session IDs using cryptographically secure random number generators (not predictable sequences)
-- **User-specific Binding**: Bind session IDs to user-specific information using secure formats like `<user_id>:<session_id>`
-- **Session Lifecycle Controls**: Implement proper session expiration, rotation, and invalidation mechanisms
-- **Session Security Headers**: Use appropriate HTTP security headers for session protection
+### 8. Secure Application State
+
+- **Cryptographic State Handles**: Generate opaque, non-deterministic handles
+	for state that spans requests
+- **User-specific Binding**: Bind each handle server-side to the authenticated
+	principal; do not trust a user ID supplied by the client
+- **Lifecycle Controls**: Expire and revoke handles, and define how callers
+	recover from stale state
+- **Per-request Authorization**: Recheck authorization whenever a handle is
+	presented; a handle is a name, not a credential
 
 ### 9. AI-Specific Security Controls
 - **Prompt Injection Defense**: Deploy Microsoft Prompt Shields with spotlighting, delimiters, and datamarking techniques
@@ -112,10 +133,10 @@ This comprehensive guide outlines essential security best practices for implemen
 - **[OWASP MCP Azure Security Guide](https://microsoft.github.io/mcp-azure-security-guide/)** - Reference architecture and OWASP MCP Top 10 implementation guidance
 
 ### Official MCP Documentation
-- [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/) - Current MCP protocol specification
-- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices) - Official security guidance
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) - Authentication and authorization patterns
-- [MCP Transport Security](https://modelcontextprotocol.io/specification/2025-11-25/transports/) - Transport layer security requirements
+- [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/) - Current MCP protocol specification
+- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices) - Official security guidance
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization) - HTTP authorization patterns
+- [MCP Transports](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/) - Transport requirements
 
 ### Microsoft Security Solutions
 - [Microsoft Prompt Shields](https://learn.microsoft.com/azure/ai-services/content-safety/concepts/jailbreak-detection) - Advanced prompt injection protection
@@ -177,7 +198,9 @@ This comprehensive guide outlines essential security best practices for implemen
 
 ---
 
-*This document reflects MCP security best practices as of December 18, 2025, based on MCP Specification 2025-11-25. Security practices should be regularly reviewed and updated as the protocol and threat landscape evolve.*
+*This document reflects MCP security best practices as of September 9, 2026,
+based on MCP Specification `2026-07-28`. Security practices should be regularly
+reviewed as the protocol and threat landscape evolve.*
 
 ## What's Next
 

--- a/02-Security/mcp-best-practices.md
+++ b/02-Security/mcp-best-practices.md
@@ -27,9 +27,7 @@ unique to MCP deployments.
 
 ### 2. Authentication & Authorization Excellence  
 - **External Identity Providers**: Delegate authentication to established identity providers (Microsoft Entra ID, OAuth 2.1 providers) rather than implementing custom authentication
-- **Client Registration**: Prefer Client ID Metadata Documents or
-	pre-registration; use deprecated Dynamic Client Registration only for
-	compatibility
+- **Client Registration**: Prefer Client ID Metadata Documents or pre-registration; use deprecated Dynamic Client Registration only for compatibility
 - **Fine-grained Permissions**: Implement granular, tool-specific permissions following the principle of least privilege
 - **Token Lifecycle Management**: Use short-lived access tokens with secure rotation and proper audience validation
 - **Multi-Factor Authentication**: Require MFA for all administrative access and sensitive operations

--- a/02-Security/mcp-security-best-practices-2025.md
+++ b/02-Security/mcp-security-best-practices-2025.md
@@ -1,6 +1,9 @@
-# MCP Security Best Practices - February 2026 Update
+# MCP Security Best Practices - September 2026 Update
 
-> **Important**: This document reflects the latest [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/) security requirements and official [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices). Always refer to the current specification for the most up-to-date guidance.
+> **Important:** This document reflects
+> [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
+> and the official
+> [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices).
 
 ## 🏔️ Hands-On Security Training
 
@@ -10,11 +13,11 @@ All practices in this document align with the **[OWASP MCP Azure Security Guide]
 
 ## Essential Security Practices for MCP Implementations
 
-The Model Context Protocol introduces unique security challenges that extend beyond traditional software security. These practices address both foundational security requirements and MCP-specific threats including prompt injection, tool poisoning, session hijacking, confused deputy problems, and token passthrough vulnerabilities.
-
-### **MANDATORY Security Requirements** 
-
-**Critical Requirements from MCP Specification:**
+The Model Context Protocol introduces unique security challenges that extend
+beyond traditional software security. These practices address foundational
+requirements and MCP-specific threats including prompt injection, tool
+poisoning, state-handle hijacking, confused deputy problems, and token
+passthrough vulnerabilities.
 
 ### **MANDATORY Security Requirements** 
 
@@ -26,7 +29,8 @@ The Model Context Protocol introduces unique security challenges that extend bey
 >  
 > **MUST NOT**: MCP servers **MUST NOT** use sessions for authentication
 >
-> **MUST**: MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically registered client
+> **MUST**: MCP proxy servers using a static third-party client ID **MUST**
+> obtain consent for each MCP client before forwarding authorization
 
 ---
 
@@ -43,18 +47,24 @@ The Model Context Protocol introduces unique security challenges that extend bey
    - Implement encryption for tokens both at rest and in transit
    - Regular credential rotation and monitoring for unauthorized access
 
-## 2. **Session Management & Transport Security**
+## 2. **State Handle & Transport Security**
 
-**Secure Session Practices:**
-   - **Cryptographically Secure Session IDs**: Use secure, non-deterministic session IDs generated with secure random number generators
-   - **User-Specific Binding**: Bind session IDs to user identities using formats like `<user_id>:<session_id>` to prevent cross-user session abuse
-   - **Session Lifecycle Management**: Implement proper expiration, rotation, and invalidation to limit vulnerability windows
-   - **HTTPS/TLS Enforcement**: Mandatory HTTPS for all communication to prevent session ID interception
+**Secure Application State Practices:**
+
+- **Opaque State Handles**: Use secure, non-deterministic handles for
+   application state that spans requests
+- **User-Specific Binding**: Bind handles server-side to the authenticated
+   principal and reject cross-user reuse
+- **Lifecycle Management**: Expire and revoke handles to limit vulnerability
+   windows
+- **Per-request Authorization**: Never treat a state handle as authentication;
+   authorize every request that presents one
 
 **Transport Layer Security:**
-   - Configure TLS 1.3 where possible with proper certificate management
-   - Implement certificate pinning for critical connections
-   - Regular certificate rotation and validity verification
+
+- Require HTTPS for remote HTTP transports in production
+- Use process isolation and environment credentials for local stdio servers
+- Configure modern TLS with proper certificate rotation and validation
 
 ## 3. **AI-Specific Threat Protection** 🤖
 
@@ -108,7 +118,11 @@ The Model Context Protocol introduces unique security challenges that extend bey
 
 **OAuth 2.1 Implementation:**
    - **PKCE Implementation**: Use Proof Key for Code Exchange (PKCE) for all authorization requests
-   - **Explicit Consent**: Obtain user consent for each dynamically registered client to prevent confused deputy attacks
+    - **Client Registration**: Prefer Client ID Metadata Documents or
+       pre-registration; use deprecated Dynamic Client Registration only as a
+       compatibility fallback
+    - **Explicit Consent**: MCP proxies using a static third-party client ID must
+       obtain consent for each MCP client before forwarding authorization
    - **Redirect URI Validation**: Implement strict validation of redirect URIs and client identifiers
 
 **Proxy Security:**
@@ -181,9 +195,9 @@ The Model Context Protocol introduces unique security challenges that extend bey
 ## **Critical Security Resources**
 
 ### **Official MCP Documentation**
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
-- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices)
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 
 ### **OWASP MCP Security Resources**
 - [OWASP MCP Azure Security Guide](https://microsoft.github.io/mcp-azure-security-guide/) - Comprehensive OWASP MCP Top 10 with Azure implementation
@@ -207,7 +221,10 @@ The Model Context Protocol introduces unique security challenges that extend bey
 
 ---
 
-> **Security Notice**: MCP security practices evolve rapidly. Always verify against the current [MCP specification](https://spec.modelcontextprotocol.io/) and [official security documentation](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices) before implementation.
+> **Security notice:** MCP security practices evolve rapidly. Always verify
+> against the current [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/)
+> and [official security documentation](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)
+> before implementation.
 
 ## What's Next
 

--- a/02-Security/mcp-security-controls-2025.md
+++ b/02-Security/mcp-security-controls-2025.md
@@ -1,6 +1,9 @@
-# MCP Security Controls - February 2026 Update
+# MCP Security Controls - September 2026 Update
 
-> **Current Standard**: This document reflects [MCP Specification 2025-11-25](https://spec.modelcontextprotocol.io/specification/2025-11-25/) security requirements and official [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices).
+> **Current standard:** This document reflects
+> [MCP Specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/)
+> and the official
+> [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices).
 
 The Model Context Protocol (MCP) has matured significantly with enhanced security controls addressing both traditional software security and AI-specific threats. This document provides comprehensive security controls for secure MCP implementations aligned with the OWASP MCP Top 10 framework.
 
@@ -20,7 +23,8 @@ All security controls in this document align with the **[OWASP MCP Azure Securit
 >
 > **REQUIRED**: MCP servers implementing authorization **MUST** verify ALL inbound requests
 >
-> **MANDATORY**: MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically registered client
+> **MANDATORY**: MCP proxy servers using a static third-party client ID
+> **MUST** obtain consent for each MCP client before forwarding authorization
 
 ---
 
@@ -28,7 +32,10 @@ All security controls in this document align with the **[OWASP MCP Azure Securit
 
 ### **External Identity Provider Integration**
 
-**Current MCP Standard (2025-11-25)** allows MCP servers to delegate authentication to external identity providers, representing a significant security improvement:
+**MCP Specification `2026-07-28`** allows MCP servers to delegate
+authentication to external identity providers. Authorization for HTTP
+transports is evaluated per request; local stdio servers obtain credentials
+from their environment instead.
 
 **OWASP MCP Risk Addressed**: [MCP07 - Insufficient Authentication & Authorization](https://microsoft.github.io/mcp-azure-security-guide/mcp/mcp07-authz/)
 
@@ -40,6 +47,9 @@ All security controls in this document align with the **[OWASP MCP Azure Securit
 5. **Conditional Access Policies**: Benefits from risk-based access controls and adaptive authentication
 
 **Implementation Requirements:**
+- **Client Registration**: Prefer Client ID Metadata Documents or
+  pre-registration; use deprecated Dynamic Client Registration only for
+  compatibility
 - **Token Audience Validation**: Verify all tokens are explicitly issued for the MCP server
 - **Issuer Verification**: Validate token issuer matches expected identity provider
 - **Signature Verification**: Cryptographic validation of token integrity
@@ -92,54 +102,57 @@ Token Lifecycle Management:
 - **Short-Lived Tokens**: Minimize exposure window with frequent token rotation
 - **Just-in-Time Issuance**: Issue tokens only when needed for specific operations
 - **Secure Storage**: Use hardware security modules (HSMs) or secure key vaults
-- **Token Binding**: Bind tokens to specific clients, sessions, or operations where possible
+- **Token Binding**: Validate token audience and issuer for the intended MCP
+  resource, client, and operation
 - **Monitoring & Alerting**: Real-time detection of token misuse or unauthorized access patterns
 
-## 3. **Session Security Controls**
+## 3. **Application State Security Controls**
 
-### **Session Hijacking Prevention**
+### **State Handle Hijacking Prevention**
 
 **Attack Vectors Addressed:**
-- **Session Hijack Prompt Injection**: Malicious events injected into shared session state
-- **Session Impersonation**: Unauthorized use of stolen session IDs to bypass authentication
-- **Resumable Stream Attacks**: Exploitation of server-sent event resumption for malicious content injection
+- **Handle Guessing**: Predictable identifiers expose another caller's state
+- **Cross-user Reuse**: A stolen handle is used with a different identity
+- **Implicit Authorization**: Possession of a handle is incorrectly treated as
+  proof of access
 
-**Mandatory Session Controls:**
+**State Handle Controls:**
+
 ```yaml
-Session ID Generation:
+State Handle Generation:
   randomness_source: "Cryptographically secure RNG"
   entropy_bits: 128 # Minimum recommended
   format: "Base64url encoded"
   predictability: "MUST be non-deterministic"
 
-Session Binding:
-  user_binding: "REQUIRED - <user_id>:<session_id>"
-  additional_identifiers: "Device fingerprint, IP validation"
-  context_binding: "Request origin, user agent validation"
+State Binding:
+  user_binding: "Bind server-side to the authenticated principal"
+  authorization: "Recheck on every request"
+  client_input: "Never trust a client-supplied user ID"
   
-Session Lifecycle:
+State Lifecycle:
   expiration: "Configurable timeout policies"
   rotation: "After privilege escalation events"
   invalidation: "Immediate on security events"
-  cleanup: "Automated expired session removal"
+  cleanup: "Automated expired state removal"
 ```
 
 **Transport Security:**
-- **HTTPS Enforcement**: All session communication over TLS 1.3
-- **Secure Cookie Attributes**: HttpOnly, Secure, SameSite=Strict
-- **Certificate Pinning**: For critical connections to prevent MITM attacks
+- **HTTPS Enforcement**: Require HTTPS for remote HTTP transports
+- **Credential Handling**: Send and validate authorization on every HTTP request
+- **stdio Isolation**: Protect local stdio servers through process isolation and
+  environment credential controls
 
 ### **Stateful vs Stateless Considerations**
 
-**For Stateful Implementations:**
-- Shared session state requires additional protection against injection attacks
-- Queue-based session management needs integrity verification
-- Multiple server instances require secure session state synchronization
+MCP `2026-07-28` is stateless at the protocol layer. Applications may still
+maintain state by returning an explicit handle from one tool call and accepting
+it as an ordinary argument on later calls.
 
-**For Stateless Implementations:**
-- JWT or similar token-based session management
-- Cryptographic verification of session state integrity
-- Reduced attack surface but requires robust token validation
+- Store state independently of any one transport connection.
+- Bind state handles to the authenticated principal server-side.
+- Treat a handle as a name, not as a bearer credential.
+- Define expiration and recovery behavior for stale handles.
 
 ## 4. **AI-Specific Security Controls**
 
@@ -211,8 +224,11 @@ Tool Definition Protection:
 **Attack Prevention Controls:**
 ```yaml
 Client Registration:
-  static_client_protection:
-    - "Explicit user consent for dynamic registration"
+  preferred_methods:
+    - "Pre-registration when client and server have an existing relationship"
+    - "Client ID Metadata Documents for clients without prior registration"
+  compatibility_fallback:
+    - "Dynamic Client Registration only when CIMD is unavailable"
     - "Consent bypass prevention mechanisms"  
     - "Cookie-based consent validation"
     - "Redirect URI strict validation"
@@ -225,7 +241,10 @@ Client Registration:
 ```
 
 **Implementation Requirements:**
-- **User Consent Verification**: Never skip consent screens for dynamic client registration
+- **Client Registration**: Prefer pre-registration or Client ID Metadata
+  Documents; treat Dynamic Client Registration as a compatibility fallback
+- **User Consent Verification**: MCP proxies using a static third-party client
+  ID must obtain per-client consent before forwarding authorization
 - **Redirect URI Validation**: Strict whitelist-based validation of redirect destinations
 - **Authorization Code Protection**: Short-lived codes with single-use enforcement
 - **Client Identity Verification**: Robust validation of client credentials and metadata
@@ -417,9 +436,9 @@ Recovery Procedures:
 ## **Implementation Resources**
 
 ### **Official MCP Documentation**
-- [MCP Specification (2025-11-25)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
-- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices)
-- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [MCP Specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/)
+- [MCP Security Best Practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices)
+- [MCP Authorization Specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 
 ### **OWASP MCP Security Resources**
 - [OWASP MCP Azure Security Guide](https://microsoft.github.io/mcp-azure-security-guide/) - Comprehensive OWASP MCP Top 10 with Azure implementation
@@ -439,7 +458,10 @@ Recovery Procedures:
 
 ---
 
-> **Important**: These security controls reflect the current MCP specification (2025-11-25). Always verify against the latest [official documentation](https://spec.modelcontextprotocol.io/) as standards continue to evolve rapidly.
+> **Important:** These security controls reflect MCP Specification
+> `2026-07-28`. Always verify against the
+> [current official documentation](https://modelcontextprotocol.io/specification/2026-07-28/)
+> as standards continue to evolve.
 
 ## What's Next
 

--- a/05-AdvancedTopics/mcp-foundry-agent-integration/README.md
+++ b/05-AdvancedTopics/mcp-foundry-agent-integration/README.md
@@ -366,7 +366,7 @@ To further enhance your MCP integration:
 - [Microsoft Foundry Documentation](https://learn.microsoft.com/azure/ai-foundry/)
 - [Model Context Protocol Samples](https://learn.microsoft.com/azure/ai-foundry/agents/how-to/tools/model-context-protocol-samples)
 - [Microsoft Foundry Agents Overview](https://learn.microsoft.com/azure/ai-foundry/agents/)
-- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [MCP Specification](https://modelcontextprotocol.io/specification/2026-07-28/)
 
 ## Support
 

--- a/05-AdvancedTopics/mcp-protocol-features/README.md
+++ b/05-AdvancedTopics/mcp-protocol-features/README.md
@@ -691,7 +691,7 @@ authorization or safety guarantees unless they come from a trusted server.
 
 - [Module 8 - Best Practices](../../08-BestPractices/README.md)
 - [5.14 - Context Engineering](../mcp-contextengineering/README.md)
-- [MCP Specification Changelog](https://spec.modelcontextprotocol.io/)
+- [MCP Specification Changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
 
 ---
 

--- a/05-AdvancedTopics/mcp-realtimesearch/README.md
+++ b/05-AdvancedTopics/mcp-realtimesearch/README.md
@@ -571,7 +571,9 @@ console.log('Search server running at http://localhost:8000/mcp');
 > 
 > These examples would require additional error handling, authentication, and specific API integration code for production use. The search API endpoints shown (`https://api.search-service.example/search`) are placeholders and would need to be replaced with actual search service endpoints.
 > 
-> For complete implementation details and the most up-to-date approaches, please refer to the [official MCP specification](https://spec.modelcontextprotocol.io/) and SDK documentation.
+> For complete implementation details and the most up-to-date approaches,
+> refer to the [official MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/)
+> and SDK documentation.
 
 ## Core Concepts
 
@@ -725,7 +727,7 @@ Advanced exercise covering:
 
 ## Additional Resources
 
-- [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/) - Official MCP specification and detailed protocol documentation
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification/2026-07-28/) - Official MCP specification and detailed protocol documentation
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io/) - Detailed tutorials and implementation guides
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) - Official Python implementation of the MCP protocol
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) - Official TypeScript implementation of the MCP protocol

--- a/09-CaseStudy/apimsample.md
+++ b/09-CaseStudy/apimsample.md
@@ -80,6 +80,11 @@ Here's how you can set up a policy to rate limit your MCP Server:
 
 Let's ensure our MCP Server is working as intended.
 
+> [!NOTE]
+> Azure API Management currently exposes this server through the Streamable
+> HTTP `/mcp` endpoint. The older HTTP+SSE `/sse` transport is deprecated and
+> should be used only with legacy clients.
+
 For this, we will use Visual Studio Code and GitHub Copilot and its Agent mode. We will add the MCP server to a *mcp.json* while. By doing so, Visual Studio Code will act as a client with agentic capabilities and end users will be able to type a prompt and interact with said server.
 
 Let's see how, to add the MCP server in Visual Studio Code:
@@ -88,7 +93,9 @@ Let's see how, to add the MCP server in Visual Studio Code:
 
 1. When prompted, select the server type: **HTTP (HTTP or Server Sent Events)**.
 
-1. Enter the URL of the MCP server in API Management. Example: **https://<apim-service-name>.azure-api.net/<api-name>-mcp/sse** (for SSE endpoint) or **https://<apim-service-name>.azure-api.net/<api-name>-mcp/mcp** (for MCP endpoint), note how the difference between the transports is `/sse` or `/mcp`.
+1. Enter the Streamable HTTP URL shown for the MCP server in API Management.
+    For example:
+    `https://<apim-service-name>.azure-api.net/<api-name>-mcp/mcp`.
 
 1. Enter a server ID of your choice. This is not an important value but it will help you remember what this server instance is.
 
@@ -97,17 +104,6 @@ Let's see how, to add the MCP server in Visual Studio Code:
   - **Workspace settings** - The server configuration is saved to a .vscode/mcp.json file only available in the current workspace.
 
     *mcp.json*
-
-    ```json
-    "servers": {
-        "APIM petstore" : {
-            "type": "sse",
-            "url": "url-to-mcp-server/sse"
-        }
-    }
-    ```
-
-    or if you choose streaming HTTP as transport it would be slightly different:
 
     ```json
     "servers": {

--- a/09-CaseStudy/publora-social-publishing.md
+++ b/09-CaseStudy/publora-social-publishing.md
@@ -64,15 +64,23 @@ The lessons below are the transferable part of this case study.
 
 ### Open discovery, authenticated execution
 
-`tools/list` is served without credentials; every `tools/call` requires a token and otherwise returns `401` with a `WWW-Authenticate` header pointing at the protected-resource metadata. (The server also answers an unauthenticated `initialize`, which matters only for clients on protocol versions before `2026-07-28`; that revision removed the handshake entirely.)
+`tools/list` is served without credentials; every `tools/call` requires a token
+and otherwise returns `401` with a `WWW-Authenticate` header pointing at the
+protected-resource metadata. The server's legacy endpoint also answers an
+unauthenticated `initialize` for clients on protocol versions before
+`2026-07-28`; current clients do not use that handshake.
 
-This split matters in practice. Registries, catalogues and clients can introspect the tool surface — names, schemas, annotations — without holding a secret, while nothing can be *executed* anonymously. A server that demands a token for `initialize` is effectively invisible to tooling; a server that allows anonymous `tools/call` is a liability.
+This server-specific split lets registries, catalogues, and clients inspect tool
+names, schemas, and annotations without a secret while preventing anonymous
+execution. Open discovery is a deployment choice, not an MCP requirement; a
+protected deployment may also require authorization for `tools/list`.
 
 ### Registration: dynamic client registration, and what replaces it
 
 The server advertises `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, and supports the authorization-code flow with PKCE (`S256`), refresh tokens, and **dynamic client registration**.
 
-Dynamic registration removes the manual step: without it every client needs a pre-issued `client_id`, which means an out-of-band request to the vendor for each new client.
+Dynamic registration removed the manual step for legacy clients: without it,
+each client needed a pre-issued `client_id` from the vendor.
 
 Treat this as compatibility behaviour rather than as the design to copy. The `2026-07-28` revision of the specification deprecates dynamic client registration in favour of Client ID Metadata Documents, where the client hosts a metadata document at a stable HTTPS URL and that URL *is* the `client_id`. DCR keeps working for now, but a server being built today should plan for CIMD and keep DCR only for older clients.
 
@@ -108,7 +116,9 @@ This turned out to be one of the most useful details of the whole surface. Revie
 
 - The publishing step moved from a browser to the same conversation where the content is written, and a draft-first habit keeps a human in the loop. Be precise about what that is: a draft is a convention, not a boundary. The same credential can schedule or publish, so anyone who needs a real approval gate has to enforce it outside the tool surface — separate credentials, or a policy layer in front of the server.
 - Per-network differences — media requirements, threading, reply controls — are handled once in the server instead of in every agent that talks to it.
-- The same server backs several MCP clients without per-client work, because discovery is open and registration is dynamic.
+- The same server backs several MCP clients without pre-issued credentials.
+    Current clients can use Client ID Metadata Documents; DCR remains a fallback
+    for older clients.
 - The design constraints above were shaped by connector-directory reviews as much as by users: annotations, OAuth and a safe test target were each required by at least one of them.
 
 ## References
@@ -116,7 +126,7 @@ This turned out to be one of the most useful details of the whole surface. Revie
 - [Publora MCP Server (source)](https://github.com/publora/mcp-server)
 - [Publora API and MCP documentation](https://docs.publora.com)
 - [MCP Registry entry: `com.publora/mcp-server`](https://registry.modelcontextprotocol.io/v0/servers?search=com.publora/mcp-server)
-- [MCP specification — Authorization](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+- [MCP specification — Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 - [MCP specification — Tool annotations](https://modelcontextprotocol.io/docs/concepts/tools)
 
 ## What's Next

--- a/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/README.md
+++ b/10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/README.md
@@ -1,6 +1,6 @@
 # Streamlining AI Workflows: Building an MCP Server with Microsoft Foundry Toolkit
 
-[![MCP Spec](https://img.shields.io/badge/MCP%20Spec-2025--11--25-blue.svg)](https://spec.modelcontextprotocol.io/specification/2025-11-25/)
+[![MCP Spec](https://img.shields.io/badge/MCP%20Spec-2025--11--25-blue.svg)](https://modelcontextprotocol.io/specification/2025-11-25/)
 [![Python](https://img.shields.io/badge/Python-3.10+-green.svg)](https://python.org)
 [![VS Code](https://img.shields.io/badge/VS%20Code-Latest-orange.svg)](https://code.visualstudio.com/)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,23 +150,23 @@ To automate validation, configure a CI job that:
 
 #### If you ship an MCP server from this repo
 
-- [ ] Read the draft changelog for MCP 7-28:
-  <https://modelcontextprotocol.io/specification/draft/changelog>
-- [ ] Run your server against SDK betas:
-  <https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28/>
+- [ ] Read the final MCP `2026-07-28` changelog:
+  <https://modelcontextprotocol.io/specification/2026-07-28/changelog>
+- [ ] Verify that the selected SDK release supports MCP `2026-07-28`:
+  <https://modelcontextprotocol.io/docs/sdk>
 - [ ] Remove session and handshake assumptions; treat each request as
   self-contained:
-  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#a-stateless-protocol>
+  <https://modelcontextprotocol.io/specification/2026-07-28/basic/lifecycle>
 - [ ] Send `Mcp-Method` and `Mcp-Name` headers for raw HTTP requests:
-  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#routable-cacheable-traceable>
+  <https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http>
 - [ ] Audit hardcoded error codes (`missing resource` moved from `-32002` to `-32602`).
-- [ ] Flag and plan migration for deprecated roots, sampling, and
-  logging:
-  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#roots-sampling-and-logging-are-deprecated>
+- [ ] Migrate deprecated Roots, Sampling, Logging, and Dynamic Client
+  Registration:
+  <https://modelcontextprotocol.io/specification/2026-07-28/deprecated>
 - [ ] Migrate off the experimental `2025-11-25` Tasks API:
-  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#tasks-graduates-to-an-extension>
+  <https://modelcontextprotocol.io/extensions/tasks>
 - [ ] Review authorization for OAuth and OpenID Connect hardening:
-  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#authorization-hardening>
+  <https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization>
 
 ### Documentation Structure
 
@@ -359,7 +359,7 @@ Follow modules in sequential order (00-11) for optimal learning:
 ### Support Resources
 
 - **Documentation**: https://modelcontextprotocol.io/
-- **Specification**: https://spec.modelcontextprotocol.io/
+- **Specification**: https://modelcontextprotocol.io/specification/2026-07-28/
 - **Community**: https://github.com/orgs/modelcontextprotocol/discussions
 - **Discord**: Microsoft Foundry Discord server
 - **Related Courses**: See README.md for other Microsoft learning paths

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,41 @@
 
 This document serves as a record of all significant changes made to the Model Context Protocol (MCP) for Beginners curriculum. Changes are documented in reverse chronological order (newest changes first).
 
+## September 9th, 2026
+
+### MCP 2026-07-28 Final Specification Alignment
+
+Updated the English curriculum from release-candidate and `2025-11-25`
+baseline guidance to the final MCP `2026-07-28` specification.
+
+- **Updated**: Current-version references, specification links, stateless
+  request guidance, `server/discover`, Streamable HTTP headers, and the Tasks
+  extension lifecycle across 38 English documentation files.
+- **Corrected**: Elicitation now uses `elicitation/create`, Sampling uses
+  `sampling/createMessage`, and `InputRequiredResult.resultType` uses
+  `"input_required"`.
+- **Replaced**: The inaccurate Root Context conversation-state lesson with a
+  protocol-accurate Roots lesson covering informational filesystem hints, the
+  current multi-round-trip flow, security boundaries, and migration options.
+- **Clarified**: Roots, Sampling, Logging, and Dynamic Client Registration are
+  deprecated in `2026-07-28`, with their recommended replacements and earliest
+  removal date documented.
+- **Labeled**: Samples that still depend on MCP `2025-11-25`, HTTP+SSE,
+  initialization handshakes, or protocol sessions are retained as legacy
+  compatibility examples rather than presented as current implementations.
+- **Security guidance**: Updated the standalone security guides to use
+  per-request authorization and explicit application state handles instead of
+  removed protocol session IDs. Client ID Metadata Documents are now the
+  preferred registration path, with DCR documented as compatibility-only.
+- **Supporting material**: Updated the study guide, contributor checklist,
+  Publora case study, and APIM case study. The APIM walkthrough now recommends
+  its current Streamable HTTP `/mcp` endpoint instead of deprecated `/sse`.
+- **Canonical links**: Replaced retired and draft specification URLs in English
+  source Markdown with versioned `2026-07-28` links, while preserving explicit
+  links to legacy versions where a sample remains pinned to older tooling.
+- **Translation scope**: Only English source files were edited; generated
+  translations and translated images remain unchanged.
+
 ## July 29th, 2026
 
 ### New Module 08 Companion: Reliability Sidecars and Safe Retries

--- a/study_guide.md
+++ b/study_guide.md
@@ -139,7 +139,7 @@ The repository is organized into twelve main sections, each focusing on differen
    - Client-server architecture
    - Key protocol components
    - Messaging patterns in MCP
-   - Forward-looking: [What's Changing in MCP: The 2026-07-28 Release Candidate](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md) — the stateless protocol core, Extensions framework, and Roots/Sampling/Logging deprecations expected in the next specification version
+  - Current specification: [What's Changed in MCP: The 2026-07-28 Specification](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md) — the stateless protocol core, Extensions framework, and Roots/Sampling/Logging deprecations
 
 3. **Security (02-Security/)**
    - Security threats in MCP-based systems
@@ -269,7 +269,7 @@ The repository includes supporting resources:
 - **Translations**: Multi-language support with automated translations of documentation
 - **Official MCP Resources**:
   - [MCP Documentation](https://modelcontextprotocol.io/)
-  - [MCP Specification](https://spec.modelcontextprotocol.io/)
+  - [MCP Specification](https://modelcontextprotocol.io/specification/2026-07-28/)
   - [MCP GitHub Repository](https://github.com/modelcontextprotocol)
 
 ## How to Use This Repository
@@ -346,6 +346,7 @@ This repository welcomes contributions from the community. See the Community Con
 
 ----
 
-*This study guide was last updated on February 5, 2026, reflecting the latest MCP Specification 2025-11-25 and provides an overview of the repository as of that date. Repository content may be updated after this date.*
-
-*Addendum (July 2, 2026): a lesson on the `2026-07-28` MCP Specification Release Candidate was added under [01-CoreConcepts](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md); the curriculum baseline remains 2025-11-25 until the new specification ships.*
+*This study guide was last updated on September 9, 2026. It reflects MCP
+Specification `2026-07-28`, the current protocol revision. Some hands-on
+examples remain explicitly versioned to `2025-11-25` while their SDKs and tools
+adopt the stateless protocol APIs.*

--- a/study_guide.md
+++ b/study_guide.md
@@ -139,7 +139,7 @@ The repository is organized into twelve main sections, each focusing on differen
    - Client-server architecture
    - Key protocol components
    - Messaging patterns in MCP
-  - Current specification: [What's Changed in MCP: The 2026-07-28 Specification](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md) — the stateless protocol core, Extensions framework, and Roots/Sampling/Logging deprecations
+   - Current specification: [What's Changed in MCP: The 2026-07-28 Specification](./01-CoreConcepts/mcp-2026-07-28-release-candidate.md) — the stateless protocol core, Extensions framework, and Roots/Sampling/Logging deprecations
 
 3. **Security (02-Security/)**
    - Security threats in MCP-based systems


### PR DESCRIPTION
# Purpose

Complete the English Markdown audit for MCP `2026-07-28` after the main curriculum update.

- Update standalone security guides from protocol-session controls to per-request authorization and explicit state-handle security.
- Prefer Client ID Metadata Documents and document Dynamic Client Registration as compatibility-only.
- Update APIM and Publora case studies to current Streamable HTTP and final authorization guidance.
- Update the study guide, contributor checklist, changelog, and remaining canonical specification links.
- Leave generated translations and translated images unchanged.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs or modules?

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Validation

- `git diff --check main...HEAD`
- All-English-Markdown MCP protocol audit
- VS Code diagnostics report no errors in changed files
- Confirmed no files under `translations/` or `translated_images/` changed