### PR TITLE
Improve README formatting and code block visibility

### DIFF
--- a/translations/ja/03-GettingStarted/03-llm-client/README.md
+++ b/translations/ja/03-GettingStarted/03-llm-client/README.md
@@ -569,7 +569,9 @@ ChatCompletionsToolDefinition ConvertFrom(string name, string description, JsonE
 
         return toolDefinitions;
     }
-    ```    In the preceding code, we've:
+    ```    
+    
+    In the preceding code, we've:
 
     - Update the function to convert the MCP tool response to an LLm tool. Let's highlight the code we added:
 

--- a/translations/ja/03-GettingStarted/03-llm-client/README.md
+++ b/translations/ja/03-GettingStarted/03-llm-client/README.md
@@ -573,7 +573,7 @@ ChatCompletionsToolDefinition ConvertFrom(string name, string description, JsonE
     
     In the preceding code, we've:
 
-    - Update the function to convert the MCP tool response to an LLm tool. Let's highlight the code we added:
+    - Update the function to convert the MCP tool response to an LLM tool. Let's highlight the code we added:
 
         ```csharp
         JsonElement propertiesElement;

--- a/translations/ja/03-GettingStarted/03-llm-client/README.md
+++ b/translations/ja/03-GettingStarted/03-llm-client/README.md
@@ -1399,7 +1399,7 @@ process_llm_response(
 ## サンプル
 
 - [Java Calculator](../samples/java/calculator/README.md)
-- [.Net Calculator](../../../../03-GettingStarted/samples/csharp)
+- [.NET Calculator](../../../../03-GettingStarted/samples/csharp)
 - [JavaScript Calculator](../samples/javascript/README.md)
 - [TypeScript Calculator](../samples/typescript/README.md)
 - [Python Calculator](../../../../03-GettingStarted/samples/python)


### PR DESCRIPTION
Fixed formatting and added a code block for clarity.

https://github.com/microsoft/mcp-for-beginners/blob/main/translations/ja/03-GettingStarted/03-llm-client/README.md 

<img width="1050" height="858" alt="image" src="https://github.com/user-attachments/assets/6640beed-cdee-4a47-9302-865859dd6acc" />

related https://github.com/microsoft/mcp-for-beginners/pull/1083

#PingMSFTDocs