### PR TITLE
drift scan: gpt-4o pin, 3 critical, 3 warning findings

### DIFF
--- a/.github/workflows/drift-scan.yml
+++ b/.github/workflows/drift-scan.yml
@@ -1,0 +1,18 @@
+# fail-on is empty on purpose: this job annotates findings and never fails CI.
+name: Drift scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 6 * * 1"
+
+jobs:
+  drift-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: 710git/course-drift-oracle@v1
+        with:
+          fail-on: ""


### PR DESCRIPTION
Scanned commit `422055c27bf1e0fc3b932e87c437a2bfa0cd17ae` of this repo with `drift_scan.py` (offline mode, catalog version 2026-08-28b): 195 files, 22 findings (3 critical, 3 warning, 16 info).

## Critical (3)

- `03-GettingStarted/03-llm-client/README.md:968` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `03-GettingStarted/03-llm-client/solution/python/client.py:22` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule
- `10-StreamliningAIWorkflowsBuildingAnMCPServerWithAIToolkit/lab2/code/agent.py:124` - `gpt-4o` is **deprecated** in the catalog, earliest retirement 2026-10-01. Replacement: `gpt-5.1`. Source: https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule

## Warnings (showing 3 of 3)

- `09-CaseStudy/docs-mcp/solution/python/requirements.txt:1` - `chainlit` has no version constraint in this requirements file (status: unpinned).
- `09-CaseStudy/docs-mcp/solution/python/requirements.txt:2` - `mcp` has no version constraint in this requirements file (status: unpinned).
- `09-CaseStudy/docs-mcp/solution/python/requirements.txt:3` - `semantic-kernel` has no version constraint in this requirements file (status: unpinned).

## What happens on the retirement date

A deprecated id keeps serving until its retirement date, then every request against it starts failing.

## Optional

```yaml
- uses: 710git/course-drift-oracle@v1
```

Runs this same scan in CI on every push; a retired id fails the job and every finding is annotated at its file and line in the pull request.

This pull request goes one step further than that line and sets `fail-on: ""` in the workflow it adds, which turns the gate off completely so the job only annotates and always passes, whatever it finds; set `fail-on: critical` (the Action's own default, or `warning`, or `info`) in `.github/workflows/drift-scan.yml` whenever you want a finding to fail the build instead.
